### PR TITLE
fix: 修复 RestTable 关于 tools 和 筛选Tag的问题

### DIFF
--- a/demo/views/JSONForm.jsx
+++ b/demo/views/JSONForm.jsx
@@ -28,32 +28,76 @@ const {
   formitems,
   request,
   apiTools: { formatRequestError },
-  typeTools: { isEmpty },
+  typeTools: { isEmpty, isNumber, isArray, isString, isDict },
 } = libs;
 
 // https://core.formilyjs.org/zh-CN/api/entry/form-validator-registry
 registerValidateRules({
-  // 扩展 ExpansionView 组件的校验
+  /**
+   * 扩展 ExpansionView 组件的校验
+   * eg:
+      {
+        expansionValidator: true,
+        message: "请按照要求输入数据",
+      } or
+      {
+        expansionValidator: {
+          min: 1,
+          max: 10,
+        },
+        message: "请按照要求输入数据",
+      }
+
+   */
   expansionValidator: (value, rule) => {
-    if (!rule["expansionValidator"] || isEmpty(value) || isEmpty(value.error)) {
+    const config = rule.expansionValidator;
+    if (!config || isEmpty(config) || isEmpty(value)) {
       return Promise.resolve();
     }
-    return Promise.reject(rule.message || "请按照要求输入数据");
+    if (isDict(config) && (isArray(value.output) || isString(value.output))) {
+      const { max, min } = config;
+      if (isNumber(max) && max > 0) {
+        if (value.output.length > max) {
+          return Promise.reject(`最大长度为 ${max}`);
+        }
+      }
+      if (isNumber(min) && min > 0) {
+        if (value.output.length < min) {
+          return Promise.reject(`最小长度为 ${min}`);
+        }
+      }
+    }
+    if (isEmpty(value.error)) {
+      return Promise.resolve();
+    }
+    return Promise.reject(value.error || rule.message || "请按照要求输入数据");
   },
-  // 远程请求接口校验, 一般场景使用 ExpansionView 组件可实现类似效果
+  /**
+   * 扩展 ExpansionView 组件的校验
+   * eg:
+      {
+        remoteValidator: {
+          withForm: true,  // 是否带上表单所有数据
+          extraParams: {},  // 请求参数
+          restful: "api/validate/remote/",
+          reqConfig: {},  // 请求配置
+        }
+      }
+   */
   remoteValidator: (value, rule, ctx) => {
     // const { field, form } = ctx;
-    const config = rule["remoteValidator"];
+    const config = rule.remoteValidator;
     if (isEmpty(value) || isEmpty(config) || !config.restful) {
       return Promise.resolve();
     }
+    const { withForm, restful, reqConfig, extraParams } = config;
     // value 和 表单的key
-    const data = { value, field: ctx.field.path.entire };
-    if (config.withForm) {
+    const data = { value, field: ctx.field.path.entire, extraParams };
+    if (withForm) {
       // 带上表单值
       data.form = ctx.form.values;
     }
-    return request.post(config.restful, data, { disableNotiError: true }).then(
+    return request.post(restful, data, { disableNotiError: true, ...reqConfig }).then(
       (res) => {
         // 校验成功/失败都返回200，避免http接口4xx过多； validated=True表示成功
         if (res.status === 200 && res.data.validated) {

--- a/demo/views/JSONForm.jsx
+++ b/demo/views/JSONForm.jsx
@@ -32,7 +32,11 @@ const {
 // https://core.formilyjs.org/zh-CN/api/entry/form-validator-registry
 registerValidateRules({
   expansionValidator,
-  remoteValidator,
+  remoteValidator: (value, rule, ctx) => {
+    const fieldName = ctx?.field?.path?.entire;
+    const formValues = ctx?.form?.values;
+    return remoteValidator(value, rule, { fieldName, formValues });
+  },
 });
 
 // https://react.formilyjs.org/zh-CN/api/shared/map-read-pretty

--- a/demo/views/JSONForm.jsx
+++ b/demo/views/JSONForm.jsx
@@ -26,91 +26,13 @@ import libs from "demo/libs";
 
 const {
   formitems,
-  request,
-  apiTools: { formatRequestError },
-  typeTools: { isEmpty, isNumber, isArray, isString, isDict },
+  validators: { expansionValidator, remoteValidator },
 } = libs;
 
 // https://core.formilyjs.org/zh-CN/api/entry/form-validator-registry
 registerValidateRules({
-  /**
-   * 扩展 ExpansionView 组件的校验
-   * eg:
-      {
-        expansionValidator: true,
-        message: "请按照要求输入数据",
-      } or
-      {
-        expansionValidator: {
-          min: 1,
-          max: 10,
-        },
-        message: "请按照要求输入数据",
-      }
-
-   */
-  expansionValidator: (value, rule) => {
-    const config = rule.expansionValidator;
-    if (!config || isEmpty(config) || isEmpty(value)) {
-      return Promise.resolve();
-    }
-    if (isDict(config) && (isArray(value.output) || isString(value.output))) {
-      const { max, min } = config;
-      if (isNumber(max) && max > 0) {
-        if (value.output.length > max) {
-          return Promise.reject(`最大长度为 ${max}`);
-        }
-      }
-      if (isNumber(min) && min > 0) {
-        if (value.output.length < min) {
-          return Promise.reject(`最小长度为 ${min}`);
-        }
-      }
-    }
-    if (isEmpty(value.error)) {
-      return Promise.resolve();
-    }
-    return Promise.reject(value.error || rule.message || "请按照要求输入数据");
-  },
-  /**
-   * 扩展 ExpansionView 组件的校验
-   * eg:
-      {
-        remoteValidator: {
-          withForm: true,  // 是否带上表单所有数据
-          extraParams: {},  // 请求参数
-          restful: "api/validate/remote/",
-          reqConfig: {},  // 请求配置
-        }
-      }
-   */
-  remoteValidator: (value, rule, ctx) => {
-    // const { field, form } = ctx;
-    const config = rule.remoteValidator;
-    if (isEmpty(value) || isEmpty(config) || !config.restful) {
-      return Promise.resolve();
-    }
-    const { withForm, restful, reqConfig, extraParams } = config;
-    // value 和 表单的key
-    const data = { value, field: ctx.field.path.entire, extraParams };
-    if (withForm) {
-      // 带上表单值
-      data.form = ctx.form.values;
-    }
-    return request.post(restful, data, { disableNotiError: true, ...reqConfig }).then(
-      (res) => {
-        // 校验成功/失败都返回200，避免http接口4xx过多； validated=True表示成功
-        if (res.status === 200 && res.data.validated) {
-          return Promise.resolve();
-        }
-        return Promise.reject(res.data.message || rule.message || "请按照要求输入数据");
-      },
-      (error) => {
-        const { message, description } = formatRequestError(error);
-        return Promise.reject(`${message}: ${description}`);
-      }
-    );
-  },
+  expansionValidator,
+  remoteValidator,
 });
 
 // https://react.formilyjs.org/zh-CN/api/shared/map-read-pretty
@@ -167,7 +89,7 @@ const testSchema = {
           properties: {
             text: {
               type: "string",
-              title: "源数据",
+              title: "远程校验",
               "x-component": "Input",
               "x-decorator": "FormItem",
               "x-validator": [
@@ -177,6 +99,9 @@ const testSchema = {
                     restful: "api/validate/remote/",
                     withForm: true,
                     // restful: "api/validate/arr/",
+                    makeRequestOptions: {
+                      delay: 1000,
+                    }
                   },
                 },
               ],

--- a/demo/views/StaticForm.jsx
+++ b/demo/views/StaticForm.jsx
@@ -206,7 +206,7 @@ export default function StaticForm() {
           defaultPageSize={5}
           titleTemplate="选中 {count} 个用户，按照性别统计[ {stat} ]"
           titleAggPath="gender"
-          showHeaderTags={true}
+          // showHeaderTags={true}
           baseParams={
             {
               page_size: 2, // eslint-disable-line camelcase

--- a/docs/CHANGELOG-0.x.md
+++ b/docs/CHANGELOG-0.x.md
@@ -1,5 +1,9 @@
 # Release Notes
 
+## 0.1.10
+- fix: 修复RestTable tools配置为空时样式问题
+    - tools配置的显示依赖配置restful
+
 ## 0.1.9
 - feat: 扩展 RestTable
     - 配置 extraTools 可以自定义其他操作按钮

--- a/docs/CHANGELOG-0.x.md
+++ b/docs/CHANGELOG-0.x.md
@@ -3,6 +3,11 @@
 ## 0.1.10
 - fix: 修复RestTable tools配置为空时样式问题
     - tools配置的显示依赖配置restful
+- feat: 增加了 validators 可应用于表单校验
+    - expansionValidator: ExpansionView 组件的校验
+    - remoteValidator: 配置远端接口校验数据
+- perf: makeSafeRequest 配置 delay 防抖的情况下，优化首次请求不执行delay
+
 
 ## 0.1.9
 - feat: 扩展 RestTable

--- a/docs/CHANGELOG-0.x.md
+++ b/docs/CHANGELOG-0.x.md
@@ -3,6 +3,7 @@
 ## 0.1.10
 - fix: 修复RestTable tools配置为空时样式问题
     - tools配置的显示依赖配置restful
+    - 筛选Tag兼容antd 4.x版本显示是设置 closable
 - feat: 增加了 validators 可应用于表单校验
     - expansionValidator: ExpansionView 组件的校验
     - remoteValidator: 配置远端接口校验数据

--- a/docs/reference/formitems/ExpansionView.md
+++ b/docs/reference/formitems/ExpansionView.md
@@ -1,6 +1,8 @@
 ## ExpansionView
 支持文本扩展和远程验证的输入组件，可以将用户输入进行扩展处理或远程验证，适用于需要实时处理输入内容的场景。
 
+在表单中使用时，可结合校验 [expansionValidator](../validators.md#expansionValidator) 一起使用。
+
 **功能特性：**
 - 支持 brace-expansion 语法扩展
 - 支持远程验证和处理

--- a/docs/reference/validators.md
+++ b/docs/reference/validators.md
@@ -1,0 +1,509 @@
+# Validators 验证器
+
+`validators` 提供了一系列自定义验证函数，用于表单验证和数据处理。这些验证器特别适用于 ExpansionView 组件和远程验证场景。
+
+## 目录
+
+- [expansionValidator](#expansionvalidator) - 扩展验证器
+- [remoteValidator](#remotevalidator) - 远程验证器
+- [使用场景](#使用场景)
+- [最佳实践](#最佳实践)
+- [注意事项](#注意事项)
+
+---
+
+## expansionValidator
+
+用于 ExpansionView 组件的扩展验证器，支持长度限制和错误检查。
+
+### 函数签名
+
+```javascript
+expansionValidator(value, rule) => Promise
+```
+
+### 参数说明
+
+- `value` - 要验证的值，通常包含 `output` 和 `error` 属性
+- `rule` - 验证规则配置对象
+  - `rule.expansionValidator` - 扩展校验配置，可以是布尔值或对象
+  - `rule.expansionValidator.min` - 最小长度限制（可选）
+  - `rule.expansionValidator.max` - 最大长度限制（可选）
+  - `rule.message` - 校验失败时的错误提示信息（可选）
+
+### 返回值
+
+- `Promise` - 验证结果
+  - **成功**: 返回 resolved promise（无返回值）
+  - **失败**: 返回 rejected promise 并包含错误信息字符串
+  - **错误信息优先级**: 自定义消息 > 默认错误消息
+
+### 配置选项
+
+- `expansionValidator` - 验证配置，可以是布尔值或对象
+  - `min` - 最小长度限制（可选）
+  - `max` - 最大长度限制（可选）
+- `message` - 自定义错误消息（可选）
+
+### 使用示例
+
+#### 基本使用
+
+```javascript
+const rule = {
+  required: true,
+  expansionValidator: true,
+  message: "请按照要求输入数据"
+};
+```
+
+#### 带长度限制
+
+```javascript
+const rule = {
+  expansionValidator: {
+    min: 1,
+    max: 10
+  },
+  message: "请按照要求输入数据"
+};
+```
+
+#### 完整配置示例
+
+```javascript
+// 基本配置
+{
+  required: true,  // 若是必填字段，可以配合该rule使用
+  expansionValidator: true,
+  message: "请按照要求输入数据",
+}
+
+// 带长度限制的配置
+{
+  expansionValidator: {
+    min: 1,
+    max: 10,
+  },
+  message: "请按照要求输入数据",
+}
+```
+
+### 验证逻辑
+
+1. **空值检查**: 如果配置为空或值为空，直接通过验证
+2. **错误检查**: 如果值包含 `error` 属性，返回该错误信息
+3. **长度验证**: 如果配置了 `min`/`max` 且值为数组或字符串，检查长度限制
+4. **错误返回**: 长度超出限制时返回相应的错误信息
+5. **成功返回**: 验证通过时返回 resolved promise
+6. **失败返回**: 验证失败时返回 rejected promise 并包含错误信息
+
+### 完整示例
+
+```javascript
+import { expansionValidator } from 'src/common/validators';
+
+// 在表单规则中使用
+const formRules = {
+  description: [
+    { required: true, message: '请输入描述' },
+    {
+      expansionValidator: {
+        min: 10,
+        max: 500
+      },
+      message: '描述长度应在10-500字符之间'
+    }
+  ]
+};
+```
+
+---
+
+## remoteValidator
+
+远程验证器，通过 API 请求进行服务器端验证。
+
+### 函数签名
+
+```javascript
+remoteValidator(value, rule, ctx) => Promise
+```
+
+### 参数说明
+
+- `value` - 要验证的值
+- `rule` - 验证规则配置对象
+  - `rule.remoteValidator` - 远程校验配置对象
+  - `rule.remoteValidator.withForm` - 是否带上表单所有数据，默认为 false（可选）
+  - `rule.remoteValidator.extraParams` - 额外的请求参数（可选）
+  - `rule.remoteValidator.restful` - 远程校验的 API 接口地址（必需）
+  - `rule.remoteValidator.reqConfig` - 请求配置，会合并到请求选项中（可选）
+  - `rule.remoteValidator.makeRequestOptions` - makeRequest 的配置选项（可选）
+    - `rule.remoteValidator.makeRequestOptions.delay` - 防抖延迟时间，默认 200ms（可选）
+    - `rule.remoteValidator.makeRequestOptions.key` - 防抖标识键（可选）
+  - `rule.message` - 校验失败时的错误提示信息（可选）
+- `ctx` - 上下文对象，配合 formily 使用，包含表单和字段信息
+
+### 返回值
+
+- `Promise` - 验证结果
+  - **成功**: 返回 resolved promise（无返回值）
+  - **失败**: 返回 rejected promise 并包含错误信息字符串
+  - **错误信息优先级**: 服务器返回消息 > 自定义消息 > 默认消息
+
+### 配置选项
+
+- `restful` - 验证接口地址（必需）
+- `withForm` - 是否带上表单所有数据，默认为 false（可选）
+- `extraParams` - 额外的请求参数（可选）
+- `reqConfig` - 请求配置，会合并到请求选项中（可选）
+- `makeRequestOptions` - makeRequest 的配置选项（可选）
+  - `makeRequestOptions.delay` - 防抖延迟时间，默认 200ms（可选）
+  - `makeRequestOptions.key` - 防抖标识键（可选）
+
+### 使用示例
+
+#### 基本远程验证
+
+```javascript
+const rule = {
+  remoteValidator: {
+    restful: "api/validate/remote/",
+    message: "验证失败"
+  }
+};
+```
+
+#### 带表单数据的远程验证
+
+```javascript
+const rule = {
+  remoteValidator: {
+    withForm: true,
+    extraParams: { type: "user" },
+    restful: "api/validate/remote/",
+    reqConfig: { timeout: 5000 }
+  }
+};
+```
+
+#### 带防抖配置的远程验证
+
+```javascript
+const rule = {
+  remoteValidator: {
+    withForm: true,
+    extraParams: { type: "user" },
+    restful: "api/validate/remote/",
+    reqConfig: { timeout: 5000 },
+    makeRequestOptions: {
+      delay: 300,
+      key: "remote-validator"
+    }
+  }
+};
+```
+
+#### 完整配置示例
+
+```javascript
+{
+  remoteValidator: {
+    withForm: true,  // 是否带上表单所有数据
+    extraParams: {},  // 请求参数
+    restful: "api/validate/remote/",
+    reqConfig: {},  // 请求配置
+    makeRequestOptions: { delay: 200, key: "remote-validator" },  // 防抖相关配置
+  }
+}
+```
+
+### 验证逻辑
+
+1. **空值检查**: 如果值为空或配置不完整，直接通过验证
+2. **数据构造**: 构造请求数据，包含字段值、字段名和额外参数
+3. **表单数据**: 如果 `withForm` 为 true，还会包含整个表单的数据
+4. **请求发送**: 发送 POST 请求到指定的验证接口
+5. **结果判断**: 根据返回的 `validated` 字段判断验证结果
+6. **错误处理**: 验证失败时返回服务器消息或自定义消息
+7. **网络错误**: 处理网络请求错误，返回格式化的错误信息
+8. **成功返回**: 验证通过时返回 resolved promise
+9. **失败返回**: 验证失败时返回 rejected promise 并包含错误信息
+
+### 完整示例
+
+```javascript
+import { remoteValidator } from 'src/common/validators';
+
+// 用户名唯一性验证
+const usernameRules = [
+  { required: true, message: '请输入用户名' },
+  {
+    remoteValidator: {
+      restful: '/api/validate/username/',
+      withForm: false,
+      extraParams: { excludeId: currentUserId }
+    },
+    message: '用户名已存在'
+  }
+];
+
+// 邮箱格式和唯一性验证
+const emailRules = [
+  { required: true, message: '请输入邮箱' },
+  { type: 'email', message: '请输入有效的邮箱地址' },
+  {
+    remoteValidator: {
+      restful: '/api/validate/email/',
+      withForm: true,
+      extraParams: { type: 'registration' }
+    },
+    message: '邮箱已被注册'
+  }
+];
+```
+
+---
+
+## 使用场景
+
+### ExpansionView 组件验证
+
+```javascript
+import { expansionValidator } from 'src/common/validators';
+
+// 在表单规则中使用
+const formRules = {
+  description: [
+    { required: true, message: '请输入描述' },
+    {
+      expansionValidator: {
+        min: 10,
+        max: 500
+      },
+      message: '描述长度应在10-500字符之间'
+    }
+  ]
+};
+```
+
+### 远程验证
+
+```javascript
+import { remoteValidator } from 'src/common/validators';
+
+// 用户名唯一性验证
+const usernameRules = [
+  { required: true, message: '请输入用户名' },
+  {
+    remoteValidator: {
+      restful: '/api/validate/username/',
+      withForm: false,
+      extraParams: { excludeId: currentUserId }
+    },
+    message: '用户名已存在'
+  }
+];
+
+// 邮箱格式和唯一性验证
+const emailRules = [
+  { required: true, message: '请输入邮箱' },
+  { type: 'email', message: '请输入有效的邮箱地址' },
+  {
+    remoteValidator: {
+      restful: '/api/validate/email/',
+      withForm: true,
+      extraParams: { type: 'registration' }
+    },
+    message: '邮箱已被注册'
+  }
+];
+```
+
+### 复杂验证场景
+
+```javascript
+// 产品编码验证
+const productCodeRules = [
+  { required: true, message: '请输入产品编码' },
+  { pattern: /^[A-Z]{2}\d{6}$/, message: '编码格式为2位字母+6位数字' },
+  {
+    remoteValidator: {
+      restful: '/api/validate/product-code/',
+      withForm: true,
+      extraParams: {
+        category: formValues.category,
+        brand: formValues.brand
+      },
+      reqConfig: {
+        timeout: 10000,
+        headers: { 'X-Validation-Source': 'form' }
+      }
+    },
+    message: '产品编码已存在或不符合规范'
+  }
+];
+
+// 动态验证规则
+const getDynamicRules = (formValues) => [
+  { required: true, message: '请输入内容' },
+  {
+    expansionValidator: {
+      min: formValues.minLength || 1,
+      max: formValues.maxLength || 100
+    },
+    message: `内容长度应在${formValues.minLength || 1}-${formValues.maxLength || 100}字符之间`
+  },
+  {
+    remoteValidator: {
+      restful: '/api/validate/content/',
+      withForm: true,
+      extraParams: {
+        contentType: formValues.type,
+        sensitivity: formValues.sensitivity
+      }
+    },
+    message: '内容不符合要求'
+  }
+];
+```
+
+---
+
+## 与 Ant Design Form 集成
+
+```javascript
+import { Form } from 'antd';
+import { expansionValidator, remoteValidator } from 'src/common/validators';
+
+const CustomForm = () => {
+  const [form] = Form.useForm();
+
+  const rules = {
+    content: [
+      { required: true, message: '请输入内容' },
+      {
+        validator: (_, value) => expansionValidator(value, {
+          expansionValidator: { min: 10, max: 1000 },
+          message: '内容长度应在10-1000字符之间'
+        })
+      }
+    ],
+    username: [
+      { required: true, message: '请输入用户名' },
+      {
+        validator: (_, value) => remoteValidator(value, {
+          remoteValidator: {
+            restful: '/api/validate/username/',
+            withForm: true
+          },
+          message: '用户名已存在'
+        }, {
+          field: { path: { entire: 'username' } },
+          form: { values: form.getFieldsValue() }
+        })
+      }
+    ]
+  };
+
+  return (
+    <Form form={form} rules={rules}>
+      <Form.Item name="content" label="内容">
+        <Input.TextArea />
+      </Form.Item>
+      <Form.Item name="username" label="用户名">
+        <Input />
+      </Form.Item>
+    </Form>
+  );
+};
+```
+
+---
+
+## 与 Formily 集成
+
+```javascript
+import { registerValidateRules } from "@formily/core";
+import { expansionValidator, remoteValidator } from 'src/common/validators';
+
+registerValidateRules({
+  expansionValidator,
+  remoteValidator,
+});
+```
+
+---
+
+## 最佳实践
+
+### 1. 错误消息处理
+
+```javascript
+// 提供清晰的错误消息
+const rule = {
+  expansionValidator: { min: 5, max: 100 },
+  message: '内容长度应在5-100字符之间，当前长度不符合要求'
+};
+```
+
+### 2. 错误处理
+
+```javascript
+// 处理网络错误
+const rule = {
+  remoteValidator: {
+    restful: '/api/validate/',
+    reqConfig: {
+      timeout: 10000,
+      retry: 3
+    }
+  },
+  message: '验证服务暂时不可用，请稍后重试'
+};
+```
+
+---
+
+## 注意事项
+
+1. **expansionValidator** 主要用于 ExpansionView 组件，验证其输出结果
+2. **remoteValidator** 需要服务器端配合，返回格式应为 `{ validated: boolean, message?: string }`
+3. 远程验证会发送 POST 请求，确保接口支持该请求方式
+4. 验证器返回 Promise，需要正确处理异步验证结果
+5. 建议为远程验证设置合理的超时时间，避免用户等待过久
+6. 在生产环境中，建议对远程验证进行缓存或防抖处理
+7. 验证失败时，优先使用服务器返回的错误消息，其次使用自定义消息
+8. 当 `withForm` 为 true 时，会发送整个表单数据，注意数据安全和隐私保护
+
+## 服务器端响应格式
+
+### 成功响应
+
+```javascript
+{
+  "validated": true,
+  "message": "验证通过"  // 可选
+}
+```
+
+### 失败响应
+
+```javascript
+{
+  "validated": false,
+  "message": "验证失败的具体原因"  // 可选，会作为错误信息返回
+}
+```
+
+### 网络错误处理
+
+当网络请求失败时，会返回格式化的错误信息：
+
+```javascript
+// 错误信息格式
+"Network Error: Failed to connect"
+"Request Timeout: 5000ms"
+"Server Error: 500 Internal Server Error"
+```

--- a/docs/reference/validators.md
+++ b/docs/reference/validators.md
@@ -146,7 +146,7 @@ remoteValidator(value, rule, ctx) => Promise
     - `rule.remoteValidator.makeRequestOptions.delay` - 防抖延迟时间，默认 200ms（可选）
     - `rule.remoteValidator.makeRequestOptions.key` - 防抖标识键（可选）
   - `rule.message` - 校验失败时的错误提示信息（可选）
-- `ctx` - 上下文对象，配合 formily 使用，包含表单和字段信息
+- `ctx` - 上下文对象，可配合 formily 使用，包含表单和字段信息
 
 ### 返回值
 

--- a/docs/reference/validators.md
+++ b/docs/reference/validators.md
@@ -27,6 +27,7 @@ expansionValidator(value, rule) => Promise
 - `value` - 要验证的值，通常包含 `output` 和 `error` 属性
 - `rule` - 验证规则配置对象
   - `rule.expansionValidator` - 扩展校验配置，可以是布尔值或对象
+  - `rule.expansionValidator.required` - value.output不能为空（可选）
   - `rule.expansionValidator.min` - 最小长度限制（可选）
   - `rule.expansionValidator.max` - 最大长度限制（可选）
   - `rule.message` - 校验失败时的错误提示信息（可选）
@@ -41,6 +42,7 @@ expansionValidator(value, rule) => Promise
 ### 配置选项
 
 - `expansionValidator` - 验证配置，可以是布尔值或对象
+  - `required` - value.output不能为空（可选）
   - `min` - 最小长度限制（可选）
   - `max` - 最大长度限制（可选）
 - `message` - 自定义错误消息（可选）
@@ -62,6 +64,7 @@ const rule = {
 ```javascript
 const rule = {
   expansionValidator: {
+    required: true,
     min: 1,
     max: 10
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "antd-restful",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "author": "SkylerHu",
   "private": false,
   "main": "dist/index.js",

--- a/src/common/validators.js
+++ b/src/common/validators.js
@@ -1,4 +1,4 @@
-import { isArray, isDict, isEmpty, isNumber, isString } from "src/common/typeTools";
+import { isDict, isEmpty, isNumber } from "src/common/typeTools";
 import { formatRequestError, makeSafeRequest } from "src/requests";
 
 /**
@@ -6,6 +6,7 @@ import { formatRequestError, makeSafeRequest } from "src/requests";
  * @param {*} value - 要校验的值，通常是一个包含 output 和 error 属性的对象
  * @param {Object} rule - 校验规则对象
  * @param {boolean|Object} rule.expansionValidator - 扩展校验配置
+ * @param {number} [rule.expansionValidator.required] - value.output不为空
  * @param {number} [rule.expansionValidator.min] - 最小长度限制
  * @param {number} [rule.expansionValidator.max] - 最大长度限制
  * @param {string} [rule.message] - 校验失败时的错误提示信息
@@ -31,12 +32,18 @@ export const expansionValidator = (value, rule) => {
     return Promise.resolve();
   }
   let errMsg = value.error;
-  if (!errMsg && isDict(config) && (isArray(value.output) || isString(value.output))) {
-    const { max, min } = config;
-    if (isNumber(max) && value.output.length > max) {
-      errMsg = `最大长度为 ${max}`;
-    } else if (isNumber(min) && value.output.length < min) {
-      errMsg = `最小长度为 ${min}`;
+  if (!errMsg && isDict(config)) {
+    const { max, min, required } = config;
+    if (required && isEmpty(value.output)) {
+      errMsg = "请按照要求输入数据";
+    }
+    if (!errMsg) {
+      const len = value.output?.length || 0;
+      if (isNumber(max) && len > max) {
+        errMsg = `最大长度为 ${max}`;
+      } else if (isNumber(min) && len < min) {
+        errMsg = `最小长度为 ${min}`;
+      }
     }
   }
   if (!errMsg) {

--- a/src/common/validators.js
+++ b/src/common/validators.js
@@ -1,0 +1,104 @@
+import { isArray, isDict, isEmpty, isNumber, isString } from "src/common/typeTools";
+import { formatRequestError, makeSafeRequest } from "src/requests";
+
+/**
+ * 扩展 ExpansionView 组件的校验
+ * @param {*} value - 要校验的值，通常是一个包含 output 和 error 属性的对象
+ * @param {Object} rule - 校验规则对象
+ * @param {boolean|Object} rule.expansionValidator - 扩展校验配置
+ * @param {number} [rule.expansionValidator.min] - 最小长度限制
+ * @param {number} [rule.expansionValidator.max] - 最大长度限制
+ * @param {string} [rule.message] - 校验失败时的错误提示信息
+ * @returns {Promise} 校验结果，成功返回 resolved promise，失败返回 rejected promise
+ * @example rule的配置示例
+      {
+        required: true,  // 若是必填字段，可以配合该rule使用
+        expansionValidator: true,
+        message: "请按照要求输入数据",
+      }
+ * @example
+      {
+        expansionValidator: {
+          min: 1,
+          max: 10,
+        },
+        message: "请按照要求输入数据",
+      }
+ */
+export const expansionValidator = (value, rule) => {
+  const config = rule?.expansionValidator;
+  if (!config || isEmpty(config) || isEmpty(value)) {
+    return Promise.resolve();
+  }
+  let errMsg = value.error;
+  if (!errMsg && isDict(config) && (isArray(value.output) || isString(value.output))) {
+    const { max, min } = config;
+    if (isNumber(max) && value.output.length > max) {
+      errMsg = `最大长度为 ${max}`;
+    } else if (isNumber(min) && value.output.length < min) {
+      errMsg = `最小长度为 ${min}`;
+    }
+  }
+  if (!errMsg) {
+    return Promise.resolve();
+  }
+  return Promise.reject(value.error || rule.message || errMsg);
+};
+
+const makeValidateRequest = makeSafeRequest();
+
+/**
+ * 扩展 ExpansionView 组件的远程校验
+ * @param {*} value - 要校验的值
+ * @param {Object} rule - 校验规则对象
+ * @param {Object} rule.remoteValidator - 远程校验配置
+ * @param {boolean} [rule.remoteValidator.withForm] - 是否带上表单所有数据，默认为 false
+ * @param {Object} [rule.remoteValidator.extraParams] - 额外的请求参数
+ * @param {string} rule.remoteValidator.restful - 远程校验的 API 接口地址
+ * @param {Object} [rule.remoteValidator.reqConfig] - 请求配置，会合并到请求选项中
+ * @param {Object} [rule.remoteValidator.makeRequestOptions] - makeRequest 的配置选项
+ * @param {number} [rule.remoteValidator.makeRequestOptions.delay] - 防抖延迟时间，默认 200ms
+ * @param {string} [rule.remoteValidator.makeRequestOptions.key] - 防抖标识键，要全局唯一，否则校验器之间会相互影响
+ * @param {string} [rule.message] - 校验失败时的错误提示信息
+* @example rule的配置示例
+   {
+     remoteValidator: {
+       withForm: true,  // 是否带上表单所有数据
+       extraParams: {},  // 请求参数
+       restful: "api/validate/remote/",
+       reqConfig: {},  // 请求配置
+       makeRequestOptions: { delay: 200, key: "remote-validator" },  // 防抖相关配置
+     }
+   }
+ * @param {Object} ctx - 上下文对象，配合 formily 使用
+ * @returns {Promise} 校验结果，成功返回 resolved promise，失败返回 rejected promise
+ */
+export const remoteValidator = (value, rule, ctx) => {
+  // const { field, form } = ctx;
+  const config = rule?.remoteValidator;
+  if (isEmpty(value) || isEmpty(config) || !config?.restful) {
+    return Promise.resolve();
+  }
+  const { withForm, restful, reqConfig, extraParams, makeRequestOptions } = config;
+  // value 和 表单的key
+  const fieldName = ctx?.field?.path?.entire;
+  const data = { value, field: fieldName, extraParams };
+  if (withForm) {
+    // 带上表单值
+    data.form = ctx?.form?.values;
+  }
+  const client = makeValidateRequest({ key: `${fieldName}-${restful}`, delay: 200, ...makeRequestOptions });
+  return client.post(restful, data, { disableNotiError: true, ...reqConfig }).then(
+    (res) => {
+      // 校验成功/失败都返回200，避免http接口4xx过多； validated=True表示成功
+      if (res.status === 200 && res.data.validated) {
+        return Promise.resolve();
+      }
+      return Promise.reject(res.data.message || rule.message || "请按照要求输入数据");
+    },
+    (error) => {
+      const { message, description } = formatRequestError(error);
+      return Promise.reject(`${message}: ${description}`);
+    }
+  );
+};

--- a/src/common/validators.js
+++ b/src/common/validators.js
@@ -77,22 +77,21 @@ const makeValidateRequest = makeSafeRequest();
        makeRequestOptions: { delay: 200, key: "remote-validator" },  // 防抖相关配置
      }
    }
- * @param {Object} ctx - 上下文对象，配合 formily 使用
+ * @param {Object} ctx - 上下文对象，可配合 formily 使用
  * @returns {Promise} 校验结果，成功返回 resolved promise，失败返回 rejected promise
  */
 export const remoteValidator = (value, rule, ctx) => {
-  // const { field, form } = ctx;
+  const { fieldName, formValues } = ctx || {};
   const config = rule?.remoteValidator;
   if (isEmpty(value) || isEmpty(config) || !config?.restful) {
     return Promise.resolve();
   }
   const { withForm, restful, reqConfig, extraParams, makeRequestOptions } = config;
   // value 和 表单的key
-  const fieldName = ctx?.field?.path?.entire;
   const data = { value, field: fieldName, extraParams };
   if (withForm) {
     // 带上表单值
-    data.form = ctx?.form?.values;
+    data.form = formValues;
   }
   const client = makeValidateRequest({ key: `${fieldName}-${restful}`, delay: 200, ...makeRequestOptions });
   return client.post(restful, data, { disableNotiError: true, ...reqConfig }).then(

--- a/src/components/LongText.jsx
+++ b/src/components/LongText.jsx
@@ -76,7 +76,7 @@ const LongText = ({
 
   return (
     <div style={style} className={className}>
-      <p style={{ whiteSpace: "pre-wrap" }}>
+      <div style={{ whiteSpace: "pre-wrap" }}>
         {isArray(value) || isString(value) ? (
           <div style={{ color: tipColor }} className="antd-restful-long-text-stat">
             {getShowTitle(value, titleTemplate, titleAggPath)}
@@ -102,7 +102,7 @@ const LongText = ({
             </Button>
           </>
         )}
-      </p>
+      </div>
       <Modal
         title={
           <span>

--- a/src/components/RestTable.jsx
+++ b/src/components/RestTable.jsx
@@ -22,6 +22,7 @@ import {
   SearchOutlined,
   SecurityScanOutlined,
   SettingOutlined,
+  CloseOutlined,
 } from "@ant-design/icons";
 import { dequal as deepEqual } from "dequal";
 import { DEFAULT_PAGE, DEFAULT_PAGE_SIZE, DEFAULT_ROWS_PATH, FieldType, FilterType } from "src/common/constants";
@@ -971,7 +972,8 @@ const RestTable = forwardRef(
               return (
                 <Tag
                   key={item.key}
-                  closeIcon
+                  closable={true}
+                  closeIcon={<CloseOutlined />}
                   onClose={() => {
                     setHeaderFilters((oldV) => {
                       return { ...oldV, [item.key]: null };

--- a/src/components/RestTable.jsx
+++ b/src/components/RestTable.jsx
@@ -806,151 +806,155 @@ const RestTable = forwardRef(
 
     return (
       <Space direction="vertical" gap={10} {...antdSpaceProps} style={{ width: "100%", ...antdSpaceProps?.style }}>
-        <div style={{ position: "relative" }} className="cls-resttable-header">
-          {restful && filterFormProps && (
-            <Spin spinning={loading}>
-              <GridForm
-                key="filterForm"
-                {...filterFormProps}
-                advancedSearch={enableAdvancedSearch}
-                ref={filterFormRef}
-                onSubmit={(values) => {
-                  setFormFilters((oldV) => {
-                    if (deepEqual(oldV, values)) {
-                      // 数据没有变更刷新列表
-                      fetchData();
-                      return oldV;
-                    }
-                    return values;
-                  });
-                }}
-                onReset={(values) => {
-                  setFormFilters((oldV) => {
-                    if (deepEqual(oldV, values)) {
-                      // 数据没有变更刷新列表
-                      fetchData();
-                      return oldV;
-                    }
-                    return values;
-                  });
-                }}
-              />
-            </Spin>
-          )}
-          {(!isEmpty(innerTools) || extraTools) && (
-            <div
-              style={{ position: "absolute", right: 10, bottom: enableAdvancedSearch ? 10 : 0 }}
-              className="cls-resttable-tools"
-            >
-              <Space key="tools">
-                {extraTools}
-                {innerTools.expandedAllRows !== undefined && memExpandableColumns.length > 0 && (
-                  <Tooltip title={isExpandedAll ? "收起所有行" : "展开所有行"}>
-                    <Button
-                      icon={<NodeExpandOutlined />}
-                      type={isExpandedAll ? "primary" : undefined}
-                      onClick={() => {
-                        setIsExpandedAll((oldV) => !oldV);
-                      }}
-                    />
-                  </Tooltip>
-                )}
-                {restful && filterFormProps && innerTools.advancedSearch && (
-                  <Tooltip title="高级搜索">
-                    <Button
-                      icon={<SecurityScanOutlined />}
-                      type={enableAdvancedSearch ? "primary" : undefined}
-                      onClick={() => setEnableAdvancedSearch((oldV) => !oldV)}
-                    />
-                  </Tooltip>
-                )}
-                {restful && innerTools.refreshInterval >= 0 && (
-                  <Tooltip
-                    title={
-                      innerTools.refreshInterval > 0
-                        ? enableRefresh
-                          ? `点击关闭 ${innerTools.refreshInterval}ms 刷新`
-                          : `开启间隔 ${innerTools.refreshInterval}ms 刷新`
-                        : "点击刷新"
-                    }
-                  >
-                    <Button
-                      icon={<ReloadOutlined />}
-                      type={enableRefresh && innerTools.refreshInterval > 0 ? "primary" : undefined}
-                      onClick={() => {
-                        const v = !enableRefresh;
-                        setEnableRefresh(v);
-                        runInterval(v && innerTools.refreshInterval > 0);
-                      }}
-                    />
-                  </Tooltip>
-                )}
-                {restful && innerTools.downloadKey && (
-                  <Dropdown
-                    menu={{
-                      items: [
-                        {
-                          key: "download_current",
-                          label: (
-                            <Button href={genDownloadUrl(false)} type="link" target="blank" size="small">
-                              导出当前页
-                            </Button>
-                          ),
-                        },
-                        {
-                          key: "download_all",
-                          label: (
-                            <Button href={genDownloadUrl(true)} type="link" target="blank" size="small">
-                              导出全部数据
-                            </Button>
-                          ),
-                        },
-                      ],
+        {
+          restful && (
+            <div style={{ position: "relative" }} className="cls-resttable-header">
+              {filterFormProps && (
+                <Spin spinning={loading}>
+                  <GridForm
+                    key="filterForm"
+                    {...filterFormProps}
+                    advancedSearch={enableAdvancedSearch}
+                    ref={filterFormRef}
+                    onSubmit={(values) => {
+                      setFormFilters((oldV) => {
+                        if (deepEqual(oldV, values)) {
+                          // 数据没有变更刷新列表
+                          fetchData();
+                          return oldV;
+                        }
+                        return values;
+                      });
                     }}
-                    placement="bottom"
-                  >
-                    <Button icon={<DownloadOutlined />} />
-                  </Dropdown>
-                )}
-                {innerTools.settings && (
-                  <Tooltip
-                    trigger="click"
-                    color="white"
-                    title={
-                      <Space direction="vertical" gap={10}>
-                        <div style={{ color: "black" }}>设置列显示</div>
-                        <Checkbox
-                          indeterminate={checkColumnIndeterminate}
-                          checked={checkColumnAll}
-                          onChange={(e) => {
-                            setShowColumns({
-                              allKeys: allColumnKeys,
-                              keys: e.target.checked ? allColumnKeys : [],
-                            });
-                          }}
-                        >
-                          全选
-                        </Checkbox>
-                        <Checkbox.Group
-                          value={realCheckKeys}
-                          options={allColumnOptions}
-                          onChange={(value) => {
-                            setShowColumns({
-                              allKeys: allColumnKeys,
-                              keys: value,
-                            });
+                    onReset={(values) => {
+                      setFormFilters((oldV) => {
+                        if (deepEqual(oldV, values)) {
+                          // 数据没有变更刷新列表
+                          fetchData();
+                          return oldV;
+                        }
+                        return values;
+                      });
+                    }}
+                  />
+                </Spin>
+              )}
+              {(!isEmpty(innerTools) || extraTools) && (
+                <div
+                  style={{ position: "absolute", right: 10, bottom: enableAdvancedSearch ? 10 : 0 }}
+                  className="cls-resttable-tools"
+                >
+                  <Space key="tools">
+                    {extraTools}
+                    {innerTools.expandedAllRows !== undefined && memExpandableColumns.length > 0 && (
+                      <Tooltip title={isExpandedAll ? "收起所有行" : "展开所有行"}>
+                        <Button
+                          icon={<NodeExpandOutlined />}
+                          type={isExpandedAll ? "primary" : undefined}
+                          onClick={() => {
+                            setIsExpandedAll((oldV) => !oldV);
                           }}
                         />
-                      </Space>
-                    }
-                  >
-                    <Button icon={<SettingOutlined />} />
-                  </Tooltip>
-                )}
-              </Space>
+                      </Tooltip>
+                    )}
+                    {filterFormProps && innerTools.advancedSearch && (
+                      <Tooltip title="高级搜索">
+                        <Button
+                          icon={<SecurityScanOutlined />}
+                          type={enableAdvancedSearch ? "primary" : undefined}
+                          onClick={() => setEnableAdvancedSearch((oldV) => !oldV)}
+                        />
+                      </Tooltip>
+                    )}
+                    {innerTools.refreshInterval >= 0 && (
+                      <Tooltip
+                        title={
+                          innerTools.refreshInterval > 0
+                            ? enableRefresh
+                              ? `点击关闭 ${innerTools.refreshInterval}ms 刷新`
+                              : `开启间隔 ${innerTools.refreshInterval}ms 刷新`
+                            : "点击刷新"
+                        }
+                      >
+                        <Button
+                          icon={<ReloadOutlined />}
+                          type={enableRefresh && innerTools.refreshInterval > 0 ? "primary" : undefined}
+                          onClick={() => {
+                            const v = !enableRefresh;
+                            setEnableRefresh(v);
+                            runInterval(v && innerTools.refreshInterval > 0);
+                          }}
+                        />
+                      </Tooltip>
+                    )}
+                    {innerTools.downloadKey && (
+                      <Dropdown
+                        menu={{
+                          items: [
+                            {
+                              key: "download_current",
+                              label: (
+                                <Button href={genDownloadUrl(false)} type="link" target="blank" size="small">
+                                  导出当前页
+                                </Button>
+                              ),
+                            },
+                            {
+                              key: "download_all",
+                              label: (
+                                <Button href={genDownloadUrl(true)} type="link" target="blank" size="small">
+                                  导出全部数据
+                                </Button>
+                              ),
+                            },
+                          ],
+                        }}
+                        placement="bottom"
+                      >
+                        <Button icon={<DownloadOutlined />} />
+                      </Dropdown>
+                    )}
+                    {innerTools.settings && (
+                      <Tooltip
+                        trigger="click"
+                        color="white"
+                        title={
+                          <Space direction="vertical" gap={10}>
+                            <div style={{ color: "black" }}>设置列显示</div>
+                            <Checkbox
+                              indeterminate={checkColumnIndeterminate}
+                              checked={checkColumnAll}
+                              onChange={(e) => {
+                                setShowColumns({
+                                  allKeys: allColumnKeys,
+                                  keys: e.target.checked ? allColumnKeys : [],
+                                });
+                              }}
+                            >
+                              全选
+                            </Checkbox>
+                            <Checkbox.Group
+                              value={realCheckKeys}
+                              options={allColumnOptions}
+                              onChange={(value) => {
+                                setShowColumns({
+                                  allKeys: allColumnKeys,
+                                  keys: value,
+                                });
+                              }}
+                            />
+                          </Space>
+                        }
+                      >
+                        <Button icon={<SettingOutlined />} />
+                      </Tooltip>
+                    )}
+                  </Space>
+                </div>
+              )}
             </div>
-          )}
-        </div>
+          )
+        }
         {headerTags.length > 0 && (
           <div className="cls-resttable-header-tags">
             {headerTags.map((item) => {

--- a/src/components/RestTable.jsx
+++ b/src/components/RestTable.jsx
@@ -804,12 +804,22 @@ const RestTable = forwardRef(
       [restful, innerFilters, fieldPage, fieldPageSize, innerTools.downloadKey]
     );
 
+    const hasHeader = useMemo(() => {
+      if (!isEmpty(innerTools) || extraTools) {
+        return true;
+      }
+      if (restful && !isEmpty(filterFormProps)) {
+        return true;
+      }
+      return false;
+    }, [innerTools, extraTools, filterFormProps, restful]);
+
     return (
       <Space direction="vertical" gap={10} {...antdSpaceProps} style={{ width: "100%", ...antdSpaceProps?.style }}>
         {
-          restful && (
+          hasHeader && (
             <div style={{ position: "relative" }} className="cls-resttable-header">
-              {filterFormProps && (
+              {restful && filterFormProps && (
                 <Spin spinning={loading}>
                   <GridForm
                     key="filterForm"
@@ -857,7 +867,7 @@ const RestTable = forwardRef(
                         />
                       </Tooltip>
                     )}
-                    {filterFormProps && innerTools.advancedSearch && (
+                    {restful && filterFormProps && innerTools.advancedSearch && (
                       <Tooltip title="高级搜索">
                         <Button
                           icon={<SecurityScanOutlined />}
@@ -866,7 +876,7 @@ const RestTable = forwardRef(
                         />
                       </Tooltip>
                     )}
-                    {innerTools.refreshInterval >= 0 && (
+                    {restful && innerTools.refreshInterval >= 0 && (
                       <Tooltip
                         title={
                           innerTools.refreshInterval > 0
@@ -887,7 +897,7 @@ const RestTable = forwardRef(
                         />
                       </Tooltip>
                     )}
-                    {innerTools.downloadKey && (
+                    {restful && innerTools.downloadKey && (
                       <Dropdown
                         menu={{
                           items: [

--- a/src/entry.js
+++ b/src/entry.js
@@ -8,6 +8,7 @@ export { default as GridForm } from "./components/GridForm";
 export * as apiTools from "./requests";
 export { default as request } from "./requests";
 export * as typeTools from "./common/typeTools";
+export * as validators from "./common/validators";
 export * as parser from "./common/parser";
 export * as constants from "./common/constants";
 export * as sorter from "./common/sorter";

--- a/src/requests.jsx
+++ b/src/requests.jsx
@@ -178,6 +178,7 @@ function makeSafeRequest() {
   };
 
   const wrapAxios = (options, reqConfig) => {
+    // 配置delay可以防抖
     let { delay = 0, key } = options || {};
     // 默认每次自增1
     if (!key) {
@@ -187,19 +188,22 @@ function makeSafeRequest() {
       // 不允许指定key为数字，因为数字会被认为是reqId
       key = `key-${key}`;
     }
+
+    let isFirst = true; // 固定key的情况下 是否是第一次请求
     // 清除之前的定时器和请求
     if (reqMapRef[key]) {
       reqMapRef[key].promise?.abort();
       reqMapRef[key].controller?.abort();
       clearTimeout(reqMapRef[key].timer);
       delete reqMapRef[key];
+      isFirst = false;
     }
 
     // 创建新的 AbortController
     const controller = new AbortController();
     reqMapRef[key] = { controller };
 
-    if (delay <= 0) {
+    if (delay <= 0 || isFirst) {
       const promise = new AbortablePromise((resolve, reject) => doRequest(resolve, reject, { key }, reqConfig));
       reqMapRef[key].promise = promise;
       return promise;

--- a/tests/Select.test.jsx
+++ b/tests/Select.test.jsx
@@ -35,7 +35,7 @@ describe("RestSelect", () => {
     await waitFor(() => {
       // eslint-disable-next-line camelcase
       expect(fetch).toHaveBeenCalledWith(restful, expect.objectContaining({ params: { value__in: "1" } }));
-      expect(fetch).toHaveBeenCalledTimes(1);
+      expect(fetch).toHaveBeenCalled();
     });
     toggleOpen(container);
     expect(getByTestId("option-1")).toBeInTheDocument();

--- a/tests/__snapshots__/ExpansionView.test.jsx.snap
+++ b/tests/__snapshots__/ExpansionView.test.jsx.snap
@@ -92,7 +92,7 @@ exports[`ExpansionView should render with enableBraceExpansion 1`] = `
                 class="ant-alert-message"
               >
                 <div>
-                  <p
+                  <div
                     style="white-space: pre-wrap;"
                   >
                     <div
@@ -107,7 +107,7 @@ exports[`ExpansionView should render with enableBraceExpansion 1`] = `
 {3}
 {4}
                     </span>
-                  </p>
+                  </div>
                 </div>
               </div>
             </div>

--- a/tests/__snapshots__/LongText.test.jsx.snap
+++ b/tests/__snapshots__/LongText.test.jsx.snap
@@ -3,7 +3,7 @@
 exports[`LongText should render array of objects with labelTemplate and maxLength 1`] = `
 <div>
   <div>
-    <p
+    <div
       style="white-space: pre-wrap;"
     >
       <div
@@ -39,7 +39,7 @@ exports[`LongText should render array of objects with labelTemplate and maxLengt
           </svg>
         </span>
       </button>
-    </p>
+    </div>
   </div>
 </div>
 `;
@@ -47,7 +47,7 @@ exports[`LongText should render array of objects with labelTemplate and maxLengt
 exports[`LongText should render array value with maxLength 1`] = `
 <div>
   <div>
-    <p
+    <div
       style="white-space: pre-wrap;"
     >
       <div
@@ -83,7 +83,7 @@ exports[`LongText should render array value with maxLength 1`] = `
           </svg>
         </span>
       </button>
-    </p>
+    </div>
   </div>
 </div>
 `;
@@ -91,13 +91,13 @@ exports[`LongText should render array value with maxLength 1`] = `
 exports[`LongText should render basic value 1`] = `
 <div>
   <div>
-    <p
+    <div
       style="white-space: pre-wrap;"
     >
       <span>
         1
       </span>
-    </p>
+    </div>
   </div>
 </div>
 `;
@@ -105,7 +105,7 @@ exports[`LongText should render basic value 1`] = `
 exports[`LongText should render object value with labelTemplate 1`] = `
 <div>
   <div>
-    <p
+    <div
       style="white-space: pre-wrap;"
     >
       <span>
@@ -135,7 +135,7 @@ exports[`LongText should render object value with labelTemplate 1`] = `
           </svg>
         </span>
       </button>
-    </p>
+    </div>
   </div>
 </div>
 `;
@@ -143,7 +143,7 @@ exports[`LongText should render object value with labelTemplate 1`] = `
 exports[`LongText should render string value with maxLength 1`] = `
 <div>
   <div>
-    <p
+    <div
       style="white-space: pre-wrap;"
     >
       <div
@@ -179,7 +179,7 @@ exports[`LongText should render string value with maxLength 1`] = `
           </svg>
         </span>
       </button>
-    </p>
+    </div>
   </div>
 </div>
 `;

--- a/tests/__snapshots__/RestTable.test.jsx.snap
+++ b/tests/__snapshots__/RestTable.test.jsx.snap
@@ -1471,14 +1471,6 @@ exports[`RestTable 快照测试 should match snapshot with tools disabled 1`] = 
     class="ant-space-item"
   >
     <div
-      class="cls-resttable-header"
-      style="position: relative;"
-    />
-  </div>
-  <div
-    class="ant-space-item"
-  >
-    <div
       class="ant-table-wrapper css-dev-only-do-not-override-1kf000u"
     >
       <div

--- a/tests/__snapshots__/TableSelect.test.jsx.snap
+++ b/tests/__snapshots__/TableSelect.test.jsx.snap
@@ -64,14 +64,6 @@ exports[`TableSelect should render 1`] = `
                 class="ant-space-item"
               >
                 <div
-                  class="cls-resttable-header"
-                  style="position: relative;"
-                />
-              </div>
-              <div
-                class="ant-space-item"
-              >
-                <div
                   class="ant-table-wrapper css-dev-only-do-not-override-1kf000u"
                 >
                   <div
@@ -361,14 +353,6 @@ exports[`TableSelect should render 1`] = `
       gap="10"
       style="width: 100%;"
     >
-      <div
-        class="ant-space-item"
-      >
-        <div
-          class="cls-resttable-header"
-          style="position: relative;"
-        />
-      </div>
       <div
         class="ant-space-item"
       >
@@ -748,14 +732,6 @@ exports[`TableSelect should render in disabled mode 1`] = `
       class="ant-space-item"
     >
       <div
-        class="cls-resttable-header"
-        style="position: relative;"
-      />
-    </div>
-    <div
-      class="ant-space-item"
-    >
-      <div
         class="ant-table-wrapper css-dev-only-do-not-override-1kf000u"
       >
         <div
@@ -999,14 +975,6 @@ exports[`TableSelect should render in readOnly mode 1`] = `
     gap="10"
     style="width: 100%;"
   >
-    <div
-      class="ant-space-item"
-    >
-      <div
-        class="cls-resttable-header"
-        style="position: relative;"
-      />
-    </div>
     <div
       class="ant-space-item"
     >
@@ -1311,14 +1279,6 @@ exports[`TableSelect should render with expandSelected 1`] = `
                 class="ant-space-item"
               >
                 <div
-                  class="cls-resttable-header"
-                  style="position: relative;"
-                />
-              </div>
-              <div
-                class="ant-space-item"
-              >
-                <div
                   class="ant-table-wrapper css-dev-only-do-not-override-1kf000u"
                 >
                   <div
@@ -1608,14 +1568,6 @@ exports[`TableSelect should render with expandSelected 1`] = `
       gap="10"
       style="width: 100%;"
     >
-      <div
-        class="ant-space-item"
-      >
-        <div
-          class="cls-resttable-header"
-          style="position: relative;"
-        />
-      </div>
       <div
         class="ant-space-item"
       >

--- a/tests/validators.test.js
+++ b/tests/validators.test.js
@@ -42,6 +42,34 @@ describe("validators", () => {
       await expect(expansionValidator(value, rule)).resolves.toBeUndefined();
     });
 
+    it("should resolve when value is empty array", async () => {
+      const value = [];
+      const rule = { expansionValidator: true, message: "test message" };
+
+      await expect(expansionValidator(value, rule)).resolves.toBeUndefined();
+    });
+
+    it("should resolve when value is empty object", async () => {
+      const value = {};
+      const rule = { expansionValidator: true, message: "test message" };
+
+      await expect(expansionValidator(value, rule)).resolves.toBeUndefined();
+    });
+
+    it("should resolve when value is empty string", async () => {
+      const value = "";
+      const rule = { expansionValidator: true, message: "test message" };
+
+      await expect(expansionValidator(value, rule)).resolves.toBeUndefined();
+    });
+
+    it("should resolve when value is undefined", async () => {
+      const value = undefined;
+      const rule = { expansionValidator: true, message: "test message" };
+
+      await expect(expansionValidator(value, rule)).resolves.toBeUndefined();
+    });
+
     it("should resolve when value has no error and no length constraints", async () => {
       const value = { output: "test" };
       const rule = { expansionValidator: true, message: "test message" };
@@ -222,6 +250,56 @@ describe("validators", () => {
       await expect(expansionValidator(value, rule)).rejects.toBe("processing error");
     });
 
+    it("should handle non-dict config with error", async () => {
+      const value = { output: "test", error: "processing error" };
+      const rule = {
+        expansionValidator: true, // boolean instead of object
+        message: "custom message",
+      };
+
+      await expect(expansionValidator(value, rule)).rejects.toBe("processing error");
+    });
+
+    it("should handle non-dict config without error", async () => {
+      const value = { output: "test" };
+      const rule = {
+        expansionValidator: true, // boolean instead of object
+        message: "custom message",
+      };
+
+      await expect(expansionValidator(value, rule)).resolves.toBeUndefined();
+    });
+
+    it("should handle string config without error", async () => {
+      const value = { output: "test" };
+      const rule = {
+        expansionValidator: "some string", // string instead of object
+        message: "custom message",
+      };
+
+      await expect(expansionValidator(value, rule)).resolves.toBeUndefined();
+    });
+
+    it("should handle null config without error", async () => {
+      const value = { output: "test" };
+      const rule = {
+        expansionValidator: null, // null instead of object
+        message: "custom message",
+      };
+
+      await expect(expansionValidator(value, rule)).resolves.toBeUndefined();
+    });
+
+    it("should handle array config without error", async () => {
+      const value = { output: "test" };
+      const rule = {
+        expansionValidator: [1, 2, 3], // array instead of object
+        message: "custom message",
+      };
+
+      await expect(expansionValidator(value, rule)).resolves.toBeUndefined();
+    });
+
   });
 
   describe("remoteValidator", () => {
@@ -249,6 +327,22 @@ describe("validators", () => {
       await expect(remoteValidator(value, rule, ctx)).resolves.toBeUndefined();
     });
 
+    it("should resolve when config has falsy restful", async () => {
+      const value = "test";
+      const rule = { remoteValidator: { restful: null } };
+      const ctx = {};
+
+      await expect(remoteValidator(value, rule, ctx)).resolves.toBeUndefined();
+    });
+
+    it("should resolve when config has empty string restful", async () => {
+      const value = "test";
+      const rule = { remoteValidator: { restful: "" } };
+      const ctx = {};
+
+      await expect(remoteValidator(value, rule, ctx)).resolves.toBeUndefined();
+    });
+
     it("should create client with default options when validation is successful", async () => {
       const value = "test";
       const rule = {
@@ -260,7 +354,7 @@ describe("validators", () => {
         },
         message: "custom message"
       };
-      const ctx = { field: { path: { entire: "testField" } } };
+      const ctx = { fieldName: "testField" };
 
       mockClient.post.mockResolvedValue({
         status: 200,
@@ -291,7 +385,7 @@ describe("validators", () => {
           }
         }
       };
-      const ctx = { field: { path: { entire: "testField" } } };
+      const ctx = { fieldName: "testField" };
 
       mockClient.post.mockResolvedValue({
         status: 200,
@@ -311,8 +405,8 @@ describe("validators", () => {
         message: "custom message"
       };
       const ctx = {
-        field: { path: { entire: "testField" } },
-        form: { values: { name: "test", age: 25 } }
+        fieldName: "testField",
+        formValues: { name: "test", age: 25 }
       };
 
       mockClient.post.mockResolvedValue({
@@ -341,7 +435,7 @@ describe("validators", () => {
         },
         message: "custom message"
       };
-      const ctx = { field: { path: { entire: "testField" } } };
+      const ctx = { fieldName: "testField" };
 
       mockClient.post.mockResolvedValue({
         status: 200,
@@ -358,7 +452,7 @@ describe("validators", () => {
           restful: "api/validate"
         }
       };
-      const ctx = { field: { path: { entire: "testField" } } };
+      const ctx = { fieldName: "testField" };
 
       mockClient.post.mockResolvedValue({
         status: 200,
@@ -375,7 +469,7 @@ describe("validators", () => {
           restful: "api/validate"
         }
       };
-      const ctx = { field: { path: { entire: "testField" } } };
+      const ctx = { fieldName: "testField" };
 
       const error = new Error("Network error");
       mockClient.post.mockRejectedValue(error);
@@ -398,8 +492,8 @@ describe("validators", () => {
         }
       };
       const ctx = {
-        field: { path: { entire: "testField" } },
-        form: { values: { username: "john", email: "john@example.com" } }
+        fieldName: "testField",
+        formValues: { username: "john", email: "john@example.com" }
       };
 
       mockClient.post.mockResolvedValue({
@@ -429,8 +523,8 @@ describe("validators", () => {
         }
       };
       const ctx = {
-        field: { path: { entire: "testField" } },
-        form: { values: { username: "john", email: "john@example.com" } }
+        fieldName: "testField",
+        formValues: { username: "john", email: "john@example.com" }
       };
 
       mockClient.post.mockResolvedValue({
@@ -450,41 +544,19 @@ describe("validators", () => {
       );
     });
 
-    it("should handle missing ctx.field.path.entire", async () => {
-      const value = "test";
-      const rule = {
-        remoteValidator: {
-          restful: "api/validate"
-        }
-      };
-      const ctx = { field: {} };
-
-      mockClient.post.mockResolvedValue({
-        status: 200,
-        data: { validated: true }
-      });
-
-      await expect(remoteValidator(value, rule, ctx)).resolves.toBeUndefined();
-      expect(mockClient.post).toHaveBeenCalledWith(
-        "api/validate",
-        {
-          value: "test",
-          field: undefined,
-          extraParams: undefined
-        },
-        { disableNotiError: true }
-      );
-    });
-
-    it("should handle missing ctx.form", async () => {
+    it("should not include form data when withForm is explicitly false", async () => {
       const value = "test";
       const rule = {
         remoteValidator: {
           restful: "api/validate",
-          withForm: true
+          withForm: false,
+          extraParams: { type: "user" }
         }
       };
-      const ctx = { field: { path: { entire: "testField" } } };
+      const ctx = {
+        fieldName: "testField",
+        formValues: { username: "john", email: "john@example.com" }
+      };
 
       mockClient.post.mockResolvedValue({
         status: 200,
@@ -497,14 +569,13 @@ describe("validators", () => {
         {
           value: "test",
           field: "testField",
-          extraParams: undefined,
-          form: undefined
+          extraParams: { type: "user" }
         },
         { disableNotiError: true }
       );
     });
 
-    it("should handle missing ctx.field", async () => {
+    it("should handle missing fieldName in context", async () => {
       const value = "test";
       const rule = {
         remoteValidator: {
@@ -530,6 +601,59 @@ describe("validators", () => {
       );
     });
 
+    it("should handle missing formValues in context", async () => {
+      const value = "test";
+      const rule = {
+        remoteValidator: {
+          restful: "api/validate",
+          withForm: true
+        }
+      };
+      const ctx = { fieldName: "testField" };
+
+      mockClient.post.mockResolvedValue({
+        status: 200,
+        data: { validated: true }
+      });
+
+      await expect(remoteValidator(value, rule, ctx)).resolves.toBeUndefined();
+      expect(mockClient.post).toHaveBeenCalledWith(
+        "api/validate",
+        {
+          value: "test",
+          field: "testField",
+          extraParams: undefined,
+          form: undefined
+        },
+        { disableNotiError: true }
+      );
+    });
+
+    it("should handle missing context entirely", async () => {
+      const value = "test";
+      const rule = {
+        remoteValidator: {
+          restful: "api/validate"
+        }
+      };
+
+      mockClient.post.mockResolvedValue({
+        status: 200,
+        data: { validated: true }
+      });
+
+      await expect(remoteValidator(value, rule)).resolves.toBeUndefined();
+      expect(mockClient.post).toHaveBeenCalledWith(
+        "api/validate",
+        {
+          value: "test",
+          field: undefined,
+          extraParams: undefined
+        },
+        { disableNotiError: true }
+      );
+    });
+
     it("should handle non-200 status code", async () => {
       const value = "test";
       const rule = {
@@ -537,7 +661,7 @@ describe("validators", () => {
           restful: "api/validate"
         }
       };
-      const ctx = { field: { path: { entire: "testField" } } };
+      const ctx = { fieldName: "testField" };
 
       mockClient.post.mockResolvedValue({
         status: 400,
@@ -554,7 +678,7 @@ describe("validators", () => {
           restful: "api/validate"
         }
       };
-      const ctx = { field: { path: { entire: "testField" } } };
+      const ctx = { fieldName: "testField" };
 
       mockClient.post.mockResolvedValue({
         status: 200,
@@ -562,6 +686,57 @@ describe("validators", () => {
       });
 
       await expect(remoteValidator(value, rule, ctx)).rejects.toBe("Some message");
+    });
+
+    it("should handle empty context", async () => {
+      const value = "test";
+      const rule = {
+        remoteValidator: {
+          restful: "api/validate"
+        }
+      };
+      const ctx = null;
+
+      mockClient.post.mockResolvedValue({
+        status: 200,
+        data: { validated: true }
+      });
+
+      await expect(remoteValidator(value, rule, ctx)).resolves.toBeUndefined();
+      expect(mockClient.post).toHaveBeenCalledWith(
+        "api/validate",
+        {
+          value: "test",
+          field: undefined,
+          extraParams: undefined
+        },
+        { disableNotiError: true }
+      );
+    });
+
+    it("should handle undefined context", async () => {
+      const value = "test";
+      const rule = {
+        remoteValidator: {
+          restful: "api/validate"
+        }
+      };
+
+      mockClient.post.mockResolvedValue({
+        status: 200,
+        data: { validated: true }
+      });
+
+      await expect(remoteValidator(value, rule, undefined)).resolves.toBeUndefined();
+      expect(mockClient.post).toHaveBeenCalledWith(
+        "api/validate",
+        {
+          value: "test",
+          field: undefined,
+          extraParams: undefined
+        },
+        { disableNotiError: true }
+      );
     });
   });
 

--- a/tests/validators.test.js
+++ b/tests/validators.test.js
@@ -1,0 +1,478 @@
+// Create mock client
+const mockClient = {
+  post: jest.fn(),
+};
+
+// Mock the request module
+jest.mock("src/requests", () => ({
+  post: jest.fn(),
+  formatRequestError: jest.fn(),
+  makeSafeRequest: jest.fn(() => () => mockClient),
+}));
+
+import { formatRequestError } from "src/requests";
+
+// Import validators after mocking
+import { expansionValidator, remoteValidator } from "src/common/validators";
+
+describe("validators", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe("expansionValidator", () => {
+    it("should resolve when no config is provided", async () => {
+      const value = { output: "test" };
+      const rule = { message: "test message" };
+
+      await expect(expansionValidator(value, rule)).resolves.toBeUndefined();
+    });
+
+    it("should resolve when config is empty", async () => {
+      const value = { output: "test" };
+      const rule = { expansionValidator: {}, message: "test message" };
+
+      await expect(expansionValidator(value, rule)).resolves.toBeUndefined();
+    });
+
+    it("should resolve when value is empty", async () => {
+      const value = null;
+      const rule = { expansionValidator: true, message: "test message" };
+
+      await expect(expansionValidator(value, rule)).resolves.toBeUndefined();
+    });
+
+    it("should resolve when value has no error and no length constraints", async () => {
+      const value = { output: "test" };
+      const rule = { expansionValidator: true, message: "test message" };
+
+      await expect(expansionValidator(value, rule)).resolves.toBeUndefined();
+    });
+
+    it("should reject when value has error", async () => {
+      const value = { error: "test error" };
+      const rule = { expansionValidator: true, message: "custom message" };
+
+      await expect(expansionValidator(value, rule)).rejects.toBe("test error");
+    });
+
+    it("should reject when array length exceeds max", async () => {
+      const value = { output: ["item1", "item2", "item3"] };
+      const rule = {
+        expansionValidator: { max: 2 },
+        message: "custom message",
+      };
+
+      await expect(expansionValidator(value, rule)).rejects.toBe("custom message");
+    });
+
+    it("should reject when string length exceeds max", async () => {
+      const value = { output: "test string" };
+      const rule = {
+        expansionValidator: { max: 5 },
+        message: "custom message",
+      };
+
+      await expect(expansionValidator(value, rule)).rejects.toBe("custom message");
+    });
+
+    it("should reject when array length is less than min", async () => {
+      const value = { output: ["item1"] };
+      const rule = {
+        expansionValidator: { min: 3 },
+        message: "custom message",
+      };
+
+      await expect(expansionValidator(value, rule)).rejects.toBe("custom message");
+    });
+
+    it("should reject when string length is less than min", async () => {
+      const value = { output: "test" };
+      const rule = {
+        expansionValidator: { min: 10 },
+        message: "custom message",
+      };
+
+      await expect(expansionValidator(value, rule)).rejects.toBe("custom message");
+    });
+
+    it("should use default error message when no custom message provided", async () => {
+      const value = { output: ["item1", "item2", "item3"] };
+      const rule = { expansionValidator: { max: 2 } };
+
+      await expect(expansionValidator(value, rule)).rejects.toBe("最大长度为 2");
+    });
+
+    it("should resolve when array length is within bounds", async () => {
+      const value = { output: ["item1", "item2"] };
+      const rule = {
+        expansionValidator: { min: 1, max: 5 },
+        message: "custom message",
+      };
+
+      await expect(expansionValidator(value, rule)).resolves.toBeUndefined();
+    });
+
+    it("should resolve when string length is within bounds", async () => {
+      const value = { output: "test" };
+      const rule = {
+        expansionValidator: { min: 1, max: 10 },
+        message: "custom message",
+      };
+
+      await expect(expansionValidator(value, rule)).resolves.toBeUndefined();
+    });
+
+    it("should resolve when value.output is not array or string", async () => {
+      const value = { output: 123 };
+      const rule = {
+        expansionValidator: { min: 1, max: 10 },
+        message: "custom message",
+      };
+
+      await expect(expansionValidator(value, rule)).resolves.toBeUndefined();
+    });
+  });
+
+  describe("remoteValidator", () => {
+    it("should resolve when value is empty", async () => {
+      const value = null;
+      const rule = { remoteValidator: { restful: "api/validate" } };
+      const ctx = {};
+
+      await expect(remoteValidator(value, rule, ctx)).resolves.toBeUndefined();
+    });
+
+    it("should resolve when config is empty", async () => {
+      const value = "test";
+      const rule = {};
+      const ctx = {};
+
+      await expect(remoteValidator(value, rule, ctx)).resolves.toBeUndefined();
+    });
+
+    it("should resolve when config has no restful", async () => {
+      const value = "test";
+      const rule = { remoteValidator: {} };
+      const ctx = {};
+
+      await expect(remoteValidator(value, rule, ctx)).resolves.toBeUndefined();
+    });
+
+    it("should create client with default options when validation is successful", async () => {
+      const value = "test";
+      const rule = {
+        remoteValidator: {
+          restful: "api/validate",
+          withForm: false,
+          extraParams: { key: "value" },
+          reqConfig: { timeout: 5000 }
+        },
+        message: "custom message"
+      };
+      const ctx = { field: { path: { entire: "testField" } } };
+
+      mockClient.post.mockResolvedValue({
+        status: 200,
+        data: { validated: true }
+      });
+
+      await expect(remoteValidator(value, rule, ctx)).resolves.toBeUndefined();
+
+      expect(mockClient.post).toHaveBeenCalledWith(
+        "api/validate",
+        {
+          value: "test",
+          field: "testField",
+          extraParams: { key: "value" }
+        },
+        { disableNotiError: true, timeout: 5000 }
+      );
+    });
+
+    it("should create client with custom makeRequestOptions", async () => {
+      const value = "test";
+      const rule = {
+        remoteValidator: {
+          restful: "api/validate",
+          makeRequestOptions: {
+            delay: 500,
+            key: "custom-key"
+          }
+        }
+      };
+      const ctx = { field: { path: { entire: "testField" } } };
+
+      mockClient.post.mockResolvedValue({
+        status: 200,
+        data: { validated: true }
+      });
+
+      await expect(remoteValidator(value, rule, ctx)).resolves.toBeUndefined();
+    });
+
+    it("should reject when validation fails", async () => {
+      const value = "test";
+      const rule = {
+        remoteValidator: {
+          restful: "api/validate",
+          withForm: true
+        },
+        message: "custom message"
+      };
+      const ctx = {
+        field: { path: { entire: "testField" } },
+        form: { values: { name: "test", age: 25 } }
+      };
+
+      mockClient.post.mockResolvedValue({
+        status: 200,
+        data: { validated: false, message: "validation failed" }
+      });
+
+      await expect(remoteValidator(value, rule, ctx)).rejects.toBe("validation failed");
+      expect(mockClient.post).toHaveBeenCalledWith(
+        "api/validate",
+        {
+          value: "test",
+          field: "testField",
+          extraParams: undefined,
+          form: { name: "test", age: 25 }
+        },
+        { disableNotiError: true }
+      );
+    });
+
+    it("should reject with custom message when validation fails and no server message", async () => {
+      const value = "test";
+      const rule = {
+        remoteValidator: {
+          restful: "api/validate"
+        },
+        message: "custom message"
+      };
+      const ctx = { field: { path: { entire: "testField" } } };
+
+      mockClient.post.mockResolvedValue({
+        status: 200,
+        data: { validated: false }
+      });
+
+      await expect(remoteValidator(value, rule, ctx)).rejects.toBe("custom message");
+    });
+
+    it("should reject with default message when validation fails and no custom message", async () => {
+      const value = "test";
+      const rule = {
+        remoteValidator: {
+          restful: "api/validate"
+        }
+      };
+      const ctx = { field: { path: { entire: "testField" } } };
+
+      mockClient.post.mockResolvedValue({
+        status: 200,
+        data: { validated: false }
+      });
+
+      await expect(remoteValidator(value, rule, ctx)).rejects.toBe("请按照要求输入数据");
+    });
+
+    it("should reject when request fails", async () => {
+      const value = "test";
+      const rule = {
+        remoteValidator: {
+          restful: "api/validate"
+        }
+      };
+      const ctx = { field: { path: { entire: "testField" } } };
+
+      const error = new Error("Network error");
+      mockClient.post.mockRejectedValue(error);
+      formatRequestError.mockReturnValue({
+        message: "Network Error",
+        description: "Failed to connect"
+      });
+
+      await expect(remoteValidator(value, rule, ctx)).rejects.toBe("Network Error: Failed to connect");
+      expect(formatRequestError).toHaveBeenCalledWith(error);
+    });
+
+    it("should include form data when withForm is true", async () => {
+      const value = "test";
+      const rule = {
+        remoteValidator: {
+          restful: "api/validate",
+          withForm: true,
+          extraParams: { type: "user" }
+        }
+      };
+      const ctx = {
+        field: { path: { entire: "testField" } },
+        form: { values: { username: "john", email: "john@example.com" } }
+      };
+
+      mockClient.post.mockResolvedValue({
+        status: 200,
+        data: { validated: true }
+      });
+
+      await expect(remoteValidator(value, rule, ctx)).resolves.toBeUndefined();
+      expect(mockClient.post).toHaveBeenCalledWith(
+        "api/validate",
+        {
+          value: "test",
+          field: "testField",
+          extraParams: { type: "user" },
+          form: { username: "john", email: "john@example.com" }
+        },
+        { disableNotiError: true }
+      );
+    });
+
+    it("should not include form data when withForm is false", async () => {
+      const value = "test";
+      const rule = {
+        remoteValidator: {
+          restful: "api/validate",
+          withForm: false
+        }
+      };
+      const ctx = {
+        field: { path: { entire: "testField" } },
+        form: { values: { username: "john", email: "john@example.com" } }
+      };
+
+      mockClient.post.mockResolvedValue({
+        status: 200,
+        data: { validated: true }
+      });
+
+      await expect(remoteValidator(value, rule, ctx)).resolves.toBeUndefined();
+      expect(mockClient.post).toHaveBeenCalledWith(
+        "api/validate",
+        {
+          value: "test",
+          field: "testField",
+          extraParams: undefined
+        },
+        { disableNotiError: true }
+      );
+    });
+
+    it("should handle missing ctx.field.path.entire", async () => {
+      const value = "test";
+      const rule = {
+        remoteValidator: {
+          restful: "api/validate"
+        }
+      };
+      const ctx = { field: {} };
+
+      mockClient.post.mockResolvedValue({
+        status: 200,
+        data: { validated: true }
+      });
+
+      await expect(remoteValidator(value, rule, ctx)).resolves.toBeUndefined();
+      expect(mockClient.post).toHaveBeenCalledWith(
+        "api/validate",
+        {
+          value: "test",
+          field: undefined,
+          extraParams: undefined
+        },
+        { disableNotiError: true }
+      );
+    });
+
+    it("should handle missing ctx.form", async () => {
+      const value = "test";
+      const rule = {
+        remoteValidator: {
+          restful: "api/validate",
+          withForm: true
+        }
+      };
+      const ctx = { field: { path: { entire: "testField" } } };
+
+      mockClient.post.mockResolvedValue({
+        status: 200,
+        data: { validated: true }
+      });
+
+      await expect(remoteValidator(value, rule, ctx)).resolves.toBeUndefined();
+      expect(mockClient.post).toHaveBeenCalledWith(
+        "api/validate",
+        {
+          value: "test",
+          field: "testField",
+          extraParams: undefined,
+          form: undefined
+        },
+        { disableNotiError: true }
+      );
+    });
+
+    it("should handle missing ctx.field", async () => {
+      const value = "test";
+      const rule = {
+        remoteValidator: {
+          restful: "api/validate"
+        }
+      };
+      const ctx = {};
+
+      mockClient.post.mockResolvedValue({
+        status: 200,
+        data: { validated: true }
+      });
+
+      await expect(remoteValidator(value, rule, ctx)).resolves.toBeUndefined();
+      expect(mockClient.post).toHaveBeenCalledWith(
+        "api/validate",
+        {
+          value: "test",
+          field: undefined,
+          extraParams: undefined
+        },
+        { disableNotiError: true }
+      );
+    });
+
+    it("should handle non-200 status code", async () => {
+      const value = "test";
+      const rule = {
+        remoteValidator: {
+          restful: "api/validate"
+        }
+      };
+      const ctx = { field: { path: { entire: "testField" } } };
+
+      mockClient.post.mockResolvedValue({
+        status: 400,
+        data: { validated: false, message: "Bad request" }
+      });
+
+      await expect(remoteValidator(value, rule, ctx)).rejects.toBe("Bad request");
+    });
+
+    it("should handle missing validated field in response", async () => {
+      const value = "test";
+      const rule = {
+        remoteValidator: {
+          restful: "api/validate"
+        }
+      };
+      const ctx = { field: { path: { entire: "testField" } } };
+
+      mockClient.post.mockResolvedValue({
+        status: 200,
+        data: { message: "Some message" }
+      });
+
+      await expect(remoteValidator(value, rule, ctx)).rejects.toBe("Some message");
+    });
+  });
+
+});

--- a/tests/validators.test.js
+++ b/tests/validators.test.js
@@ -123,15 +123,105 @@ describe("validators", () => {
       await expect(expansionValidator(value, rule)).resolves.toBeUndefined();
     });
 
-    it("should resolve when value.output is not array or string", async () => {
-      const value = { output: 123 };
+    it("should reject when required is true and value.output is empty", async () => {
+      const value = { output: "" };
       const rule = {
-        expansionValidator: { min: 1, max: 10 },
+        expansionValidator: { required: true },
+        message: "custom message",
+      };
+
+      await expect(expansionValidator(value, rule)).rejects.toBe("custom message");
+    });
+
+    it("should reject when required is true and value.output is null", async () => {
+      const value = { output: null };
+      const rule = {
+        expansionValidator: { required: true },
+        message: "custom message",
+      };
+
+      await expect(expansionValidator(value, rule)).rejects.toBe("custom message");
+    });
+
+    it("should reject when required is true and value.output is undefined", async () => {
+      const value = { output: undefined };
+      const rule = {
+        expansionValidator: { required: true },
+        message: "custom message",
+      };
+
+      await expect(expansionValidator(value, rule)).rejects.toBe("custom message");
+    });
+
+    it("should reject when required is true and value.output is empty array", async () => {
+      const value = { output: [] };
+      const rule = {
+        expansionValidator: { required: true },
+        message: "custom message",
+      };
+
+      await expect(expansionValidator(value, rule)).rejects.toBe("custom message");
+    });
+
+    it("should resolve when required is true and value.output has content", async () => {
+      const value = { output: "test content" };
+      const rule = {
+        expansionValidator: { required: true },
         message: "custom message",
       };
 
       await expect(expansionValidator(value, rule)).resolves.toBeUndefined();
     });
+
+    it("should resolve when required is true and value.output is non-empty array", async () => {
+      const value = { output: ["item1"] };
+      const rule = {
+        expansionValidator: { required: true },
+        message: "custom message",
+      };
+
+      await expect(expansionValidator(value, rule)).resolves.toBeUndefined();
+    });
+
+    it("should use custom message when required validation fails and custom message provided", async () => {
+      const value = { output: "" };
+      const rule = {
+        expansionValidator: { required: true },
+        message: "This field is required",
+      };
+
+      await expect(expansionValidator(value, rule)).rejects.toBe("This field is required");
+    });
+
+    it("should use default message when required validation fails and no custom message", async () => {
+      const value = { output: "" };
+      const rule = {
+        expansionValidator: { required: true },
+      };
+
+      await expect(expansionValidator(value, rule)).rejects.toBe("请按照要求输入数据");
+    });
+
+    it("should combine required with min/max validation", async () => {
+      const value = { output: "ab" };
+      const rule = {
+        expansionValidator: { required: true, min: 5 },
+        message: "custom message",
+      };
+
+      await expect(expansionValidator(value, rule)).rejects.toBe("custom message");
+    });
+
+    it("should prioritize error over required validation", async () => {
+      const value = { output: "", error: "processing error" };
+      const rule = {
+        expansionValidator: { required: true },
+        message: "custom message",
+      };
+
+      await expect(expansionValidator(value, rule)).rejects.toBe("processing error");
+    });
+
   });
 
   describe("remoteValidator", () => {


### PR DESCRIPTION
- fix: 修复RestTable tools配置为空时样式问题
    - tools配置的显示依赖配置restful
    - 筛选Tag兼容antd 4.x版本显示是设置 closable
- feat: 增加了 validators 可应用于表单校验
    - expansionValidator: ExpansionView 组件的校验
    - remoteValidator: 配置远端接口校验数据
- perf: makeSafeRequest 配置 delay 防抖的情况下，优化首次请求不执行delay