### PR TITLE
feat: 新增 `RestList` 组件

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,14 +21,36 @@
 
 使用示例：
 ```jsx
+// 默认导入（CommonJS 兼容场景）
 import antdRestful from "antd-restful";
+// 某些构建环境下需要使用 namespace import
+// import * as antdRestful from "antd-restful";
 
 const {
   GridForm, RestTable,
-  formitems: { RestSelect, RestTable },
+  request,
+  formitems: { RestSelect },
+  apiTools: { useSafeRequest },
   constants: { FieldType },
   typeTools: { isEmpty },
 } = antdRestful;
+```
+
+最常见的用法——在组件中发起安全的 HTTP 请求：
+```jsx
+import antdRestful from "antd-restful";
+const { apiTools: { useSafeRequest } } = antdRestful;
+
+function UserList() {
+  const [makeRequest] = useSafeRequest();
+  const [users, setUsers] = useState([]);
+
+  useEffect(() => {
+    makeRequest().get('/api/users').then((resp) => setUsers(resp.data));
+  }, []);
+
+  return <RestTable dataSource={users} columns={[{ title: '名称', dataIndex: 'name' }]} />;
+}
 ```
 
 ## 二. 使用(Usage)
@@ -78,7 +100,7 @@ setGlobalConfig({
 
 | 模块 | 说明 |
 |------|------|
-| [requests](./docs/reference/requests.md) | HTTP 请求模块，提供 axios 实例、拦截器、useSafeRequest 等 |
+| [apiTools](./docs/reference/requests.md) | HTTP 请求模块，提供 axios 实例、拦截器、useSafeRequest 等 |
 | [hooks](./docs/reference/hooks.md) | React Hooks 集合：localStorage/sessionStorage、定时器、防抖等 |
 | [typeTools](./docs/reference/typeTools.md) | 类型判断工具函数：isNull、isBlank 等 |
 

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # antd-restful
 
 [![NPM Version](https://img.shields.io/npm/v/antd-restful)](https://www.npmjs.com/package/antd-restful)
-[![GitHub Actions Workflow Status](https://github.com/SkylerHu/antd-restful/actions/workflows/test.yml/badge.svg?branch=master)](https://github.com/SkylerHu/antd-restful)
-[![Coveralls](https://img.shields.io/coverallsCoverage/github/SkylerHu/antd-restful)](https://github.com/SkylerHu/antd-restful)
-[![GitHub License](https://img.shields.io/github/license/SkylerHu/antd-restful)](https://github.com/SkylerHu/antd-restful)
+[![GitHub Actions Workflow Status](https://github.com/skylerhu/antd-restful/actions/workflows/test.yml/badge.svg?branch=master)](https://github.com/skylerhu/antd-restful)
+[![Coveralls](https://img.shields.io/coverallsCoverage/github/skylerhu/antd-restful)](https://github.com/skylerhu/antd-restful)
+[![GitHub License](https://img.shields.io/github/license/skylerhu/antd-restful)](https://github.com/skylerhu/antd-restful)
 
 
 基于 `React` + `Antd Design` 组件，扩展组件支持配置即可支持远程获取restful接口的数据。对接远程接口根据restful标准化、降低使用成本，也可以用于动态表单中的JSON配置。
@@ -47,27 +47,40 @@ setGlobalConfig({
 })
 ```
 
-- [通用组件](#21-通用组件)
-  - [RestTable](./docs/reference/RestTable.md)
-  - [GridForm](./docs/reference/GridForm.md)
-  - [LongText](./docs/reference/LongText.md)
-  - [CopyView](./docs/reference/CopyView.md)
-  - [RouteBaseTable](./docs/reference/RouteBaseTable.md)
-- [表单项(formitems)](#22-表单项formitems)
-  - [RestSelect](./docs/reference/formitems/RestSelect.md)
-  - [DateStrPicker](./docs/reference/formitems/DateStrPicker.md)
-  - [RangeStrPicker](./docs/reference/formitems/RangeStrPicker.md)
-  - [ExpansionView](./docs/reference/formitems/ExpansionView.md)
-  - [NumberRange](./docs/reference/formitems/NumberRange.md)
-  - [TableSelect](./docs/reference/formitems/TableSelect.md)
-  - [UploadView](./docs/reference/formitems/UploadView.md)
-  - [CompareEdit](./docs/reference/formitems/CompareEdit.md)
-  - [RestAutoComplete](./docs/reference/formitems/RestAutoComplete.md)
-  - [RestCascader](./docs/reference/formitems/RestCascader.md)
-  - [RestTreeSelect](./docs/reference/formitems/RestTreeSelect.md)
-  - [MentionView](./docs/reference/formitems/MentionView.md)
-- [hooks](./docs/reference/hooks.md)
-- [typeTools](./docs/reference/typeTools.md)
+### 2.1 通用组件
+
+| 组件 | 说明 |
+|------|------|
+| [RestTable](./docs/reference/RestTable.md) | Table 的 RESTful 封装，支持远程数据加载、筛选、工具栏及列设置 |
+| [GridForm](./docs/reference/GridForm.md) | 响应式栅格表单，支持多种字段类型与校验 |
+| [LongText](./docs/reference/LongText.md) | 长文本截断展示，支持弹窗查看完整内容与模板格式化 |
+| [CopyView](./docs/reference/CopyView.md) | 一键复制文本，支持字符串、数组、对象等多种数据类型 |
+| [RouteBaseTable](./docs/reference/RouteBaseTable.md) | RestTable 变体，将筛选参数同步到 URL，刷新后恢复筛选状态 |
+
+### 2.2 表单项 (formitems)
+
+| 组件 | 说明 |
+|------|------|
+| [RestSelect](./docs/reference/formitems/RestSelect.md) | Select 远程选项加载，支持搜索、缓存与多选 |
+| [DateStrPicker](./docs/reference/formitems/DateStrPicker.md) | 日期选择器，以字符串而非 dayjs 对象读写值 |
+| [RangeStrPicker](./docs/reference/formitems/RangeStrPicker.md) | 日期范围选择器，以字符串或字符串数组读写值 |
+| [ExpansionView](./docs/reference/formitems/ExpansionView.md) | 花括号展开输入框，支持远程校验与错误提示 |
+| [NumberRange](./docs/reference/formitems/NumberRange.md) | 闭区间数字范围输入，适用于价格、年龄等范围场景 |
+| [TableSelect](./docs/reference/formitems/TableSelect.md) | 基于 RestTable 的多选弹窗，展示已选行并支持取消选择 |
+| [UploadView](./docs/reference/formitems/UploadView.md) | 文件上传，支持拖拽、进度条、预览及大小/数量限制 |
+| [CompareEdit](./docs/reference/formitems/CompareEdit.md) | 差异对比编辑器，可视化展示当前值与历史值的变更 |
+| [RestAutoComplete](./docs/reference/formitems/RestAutoComplete.md) | 远程搜索自动补全，支持防抖与自定义字段映射 |
+| [RestCascader](./docs/reference/formitems/RestCascader.md) | 远程级联选择，支持懒加载与多选 |
+| [RestTreeSelect](./docs/reference/formitems/RestTreeSelect.md) | 远程树形选择，支持懒加载与多选 |
+| [MentionView](./docs/reference/formitems/MentionView.md) | 远程 @提及输入框，支持搜索与防抖 |
+
+### 2.3 工具与 Hooks
+
+| 模块 | 说明 |
+|------|------|
+| [requests](./docs/reference/requests.md) | HTTP 请求模块，提供 axios 实例、拦截器、useSafeRequest 等 |
+| [hooks](./docs/reference/hooks.md) | React Hooks 集合：localStorage/sessionStorage、定时器、防抖等 |
+| [typeTools](./docs/reference/typeTools.md) | 类型判断工具函数：isNull、isBlank 等 |
 
 
 ## 三、应用场景

--- a/README.md
+++ b/README.md
@@ -74,10 +74,11 @@ setGlobalConfig({
 | 组件 | 说明 |
 |------|------|
 | [RestTable](./docs/reference/RestTable.md) | Table 的 RESTful 封装，支持远程数据加载、筛选、工具栏及列设置 |
+| [RestList](./docs/reference/RestList.md) | List 的 RESTful 封装，支持 loadMore / pagination 两种分页模式、筛选表单及 Grid 布局 |
 | [GridForm](./docs/reference/GridForm.md) | 响应式栅格表单，支持多种字段类型与校验 |
 | [LongText](./docs/reference/LongText.md) | 长文本截断展示，支持弹窗查看完整内容与模板格式化 |
 | [CopyView](./docs/reference/CopyView.md) | 一键复制文本，支持字符串、数组、对象等多种数据类型 |
-| [RouteBaseTable](./docs/reference/RouteBaseTable.md) | RestTable 变体，将筛选参数同步到 URL，刷新后恢复筛选状态 |
+| [RouteBaseTable](./docs/reference/RouteBaseTable.md) | RestTable/RestList 的路由联动封装，通过 viewType 切换表格/列表，将筛选参数同步到 URL |
 
 ### 2.2 表单项 (formitems)
 
@@ -106,5 +107,6 @@ setGlobalConfig({
 
 
 ## 三、应用场景
-- [依赖restful接口的列表数据展示](./demo/views/TableDemo.jsx)
+- [依赖restful接口的表格数据展示](./demo/views/TableDemo.jsx)
+- [依赖restful接口的列表数据展示](./demo/views/ListDemo.jsx)
 - [动态表单中的应用](./demo/views/JSONForm.jsx)

--- a/demo/Main.jsx
+++ b/demo/Main.jsx
@@ -5,6 +5,7 @@ import ReadView from "./views/ReadView";
 import DynamicForm from "./views/StaticForm";
 import JSONForm from "./views/JSONForm";
 import TableDemo from "./views/TableDemo";
+import ListDemo from "./views/ListDemo";
 
 export default function Main() {
   const navigate = useNavigate();
@@ -34,6 +35,11 @@ export default function Main() {
           key: "table",
           label: "TableDemo & RouteTable",
           children: <TableDemo />,
+        },
+        {
+          key: "list",
+          label: "ListDemo",
+          children: <ListDemo />,
         },
       ]}
       onChange={(key) => {

--- a/demo/views/ListDemo.jsx
+++ b/demo/views/ListDemo.jsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { Avatar, Card, Tag } from "antd";
+import { Avatar, Button, Card, Tag } from "antd";
 import { UserOutlined } from "@ant-design/icons";
 import { useLocation, useNavigate } from "react-router";
 import libs from "demo/libs";
@@ -69,11 +69,15 @@ const ListDemo = () => {
         }}
       />
 
-      <h3 style={{ marginTop: 40 }}>基础列表（loadMore）</h3>
+      <h3 style={{ marginTop: 40 }}>基础列表（loadMore + loadMoreProps 自定义文案和样式）</h3>
       <RestList
         restful="api/users/"
         defaultPageSize={2}
         rowKey="id"
+        loadMoreProps={{
+          text: "点击加载更多用户",
+          style: { marginTop: 20, marginBottom: 20 },
+        }}
         filterFormProps={{
           advancedSearch: true,
           antdListProps: {
@@ -120,12 +124,21 @@ const ListDemo = () => {
         )}
       />
 
-      <h3 style={{ marginTop: 40 }}>Grid 卡片列表（loadMore + grid）</h3>
+      <h3 style={{ marginTop: 40 }}>Grid 卡片列表（loadMore + grid + loadMoreProps.render 自定义渲染）</h3>
       <RestList
         restful="api/users/"
         defaultPageSize={4}
         rowKey="id"
         grid={{ gutter: 16, column: 2 }}
+        loadMoreProps={{
+          render: (fetchMore, loadingMore) => (
+            <div style={{ textAlign: "center", padding: "16px 0" }}>
+              <Button type="dashed" onClick={fetchMore} loading={loadingMore} style={{ width: 200 }}>
+                {loadingMore ? "努力加载中..." : "展开更多卡片"}
+              </Button>
+            </div>
+          ),
+        }}
         renderItem={(item) => (
           <RestList.Item key={item.id} style={{ height: "100%" }}>
             <Card style={{ height: "100%" }}>

--- a/demo/views/ListDemo.jsx
+++ b/demo/views/ListDemo.jsx
@@ -1,0 +1,163 @@
+import React from "react";
+import { Avatar, Card, Tag } from "antd";
+import { UserOutlined } from "@ant-design/icons";
+import { useLocation, useNavigate } from "react-router";
+import libs from "demo/libs";
+
+const {
+  RestList,
+  RouteBaseTable,
+  constants: { FieldType, ViewType },
+} = libs;
+
+const ListDemo = () => {
+  const location = useLocation();
+  const navigate = useNavigate();
+
+  return (
+    <div style={{ width: "80%", margin: "0 auto" }}>
+      <h3>RouteBaseTable + viewType=list + pagination（联动路由 + 分页）</h3>
+      <RouteBaseTable
+        viewType={ViewType.LIST}
+        location={location}
+        onSearchChange={(search) => {
+          navigate(`${location.pathname}${search}`);
+        }}
+        restProps={{
+          restful: "api/users/",
+          defaultPageSize: 2,
+          rowKey: "id",
+          grid: { gutter: 16, column: 2 },
+          pagination: { showSizeChanger: true, pageSizeOptions: [2, 4, 10] },
+          filterFormProps: {
+            advancedSearch: true,
+            antdListProps: {
+              grid: { gutter: 30, column: 3 },
+            },
+            fields: [
+              {
+                key: "search",
+                label: "搜索",
+                type: FieldType.INPUT,
+              },
+              {
+                key: "gender",
+                label: "性别",
+                type: FieldType.RADIO,
+                antdFieldProps: {
+                  options: [
+                    { label: "全部", value: "" },
+                    { label: "男", value: "male" },
+                    { label: "女", value: "female" },
+                  ],
+                },
+              },
+            ],
+          },
+          renderItem: (item) => (
+            <RestList.Item key={item.id} style={{ height: "100%" }}>
+              <Card style={{ height: "100%" }}>
+                <p>昵称: {item.nickname || item.username}</p>
+                <p>用户名: {item.username}</p>
+                <p>
+                  状态:{" "}
+                  {item.is_active ? <Tag color="green">活跃</Tag> : <Tag color="red">禁用</Tag>}
+                </p>
+              </Card>
+            </RestList.Item>
+          ),
+        }}
+      />
+
+      <h3 style={{ marginTop: 40 }}>基础列表（loadMore）</h3>
+      <RestList
+        restful="api/users/"
+        defaultPageSize={2}
+        rowKey="id"
+        filterFormProps={{
+          advancedSearch: true,
+          antdListProps: {
+            grid: { gutter: 30, column: 3 },
+          },
+          fields: [
+            {
+              key: "search",
+              label: "搜索",
+              type: FieldType.INPUT,
+            },
+            {
+              key: "gender",
+              label: "性别",
+              type: FieldType.RADIO,
+              antdFieldProps: {
+                options: [
+                  { label: "全部", value: "" },
+                  { label: "男", value: "male" },
+                  { label: "女", value: "female" },
+                ],
+              },
+            },
+          ],
+        }}
+        renderItem={(item) => (
+          <RestList.Item key={item.id}>
+            <RestList.Item.Meta
+              avatar={<Avatar icon={<UserOutlined />} />}
+              title={item.nickname || item.username}
+              description={
+                <>
+                  <span>@{item.username}</span>
+                  {item.gender && (
+                    <Tag color={item.gender === "male" ? "blue" : "pink"} style={{ marginLeft: 8 }}>
+                      {item.gender === "male" ? "男" : "女"}
+                    </Tag>
+                  )}
+                  {item.age !== undefined && <span style={{ marginLeft: 8 }}>年龄: {item.age}</span>}
+                </>
+              }
+            />
+          </RestList.Item>
+        )}
+      />
+
+      <h3 style={{ marginTop: 40 }}>Grid 卡片列表（loadMore + grid）</h3>
+      <RestList
+        restful="api/users/"
+        defaultPageSize={4}
+        rowKey="id"
+        grid={{ gutter: 16, column: 2 }}
+        renderItem={(item) => (
+          <RestList.Item key={item.id} style={{ height: "100%" }}>
+            <Card style={{ height: "100%" }}>
+              <p>昵称: {item.nickname || item.username}</p>
+              <p>用户名: {item.username}</p>
+              <p>
+                状态:{" "}
+                {item.is_active ? <Tag color="green">活跃</Tag> : <Tag color="red">禁用</Tag>}
+              </p>
+              <p>城市: {item.city?.name || "-"}</p>
+              <p>分数: {item.score ?? "-"}</p>
+            </Card>
+          </RestList.Item>
+        )}
+      />
+
+      <h3 style={{ marginTop: 40 }}>Grid 列校验（page_size=3, column=2 触发 console.error）</h3>
+      <RestList
+        restful="api/users/"
+        defaultPageSize={3}
+        rowKey="id"
+        grid={{ gutter: 16, column: 2 }}
+        renderItem={(item) => (
+          <RestList.Item key={item.id}>
+            <Card title={item.nickname || item.username}>
+              <p>ID: {item.id}</p>
+            </Card>
+          </RestList.Item>
+        )}
+      />
+    </div>
+  );
+};
+
+export default ListDemo;

--- a/docs/CHANGELOG-0.x.md
+++ b/docs/CHANGELOG-0.x.md
@@ -1,5 +1,16 @@
 # Release Notes
 
+## 0.3.0
+- feat: 新增 `RestList` 组件，基于 Ant Design List 封装，支持远程数据加载
+    - 支持 loadMore（加载更多）和 pagination（分页器）两种模式，pagination 优先级高于 loadMore
+    - 支持 filterFormProps 筛选表单，渲染在 List header 中
+    - 支持 grid 栅格布局，并校验 page_size 与 grid.column 的倍数关系（不满足时 console.error）
+    - renderItem 直接暴露，不封装 List.Item；提供 `RestList.Item` 等同于 `List.Item`
+- feat: 新增 `ViewType` 枚举（`constants.ViewType`），包含 TABLE 和 LIST 两个值
+- feat: `RouteBaseTable` 新增 `viewType` 参数，支持通过 `ViewType.LIST` 切换为 RestList 渲染
+    - viewType="list" 推荐与 pagination 配合使用，不推荐与 loadMore 结合
+- docs: 优化组件使用说明文档
+
 ## 0.2.4
 - fix: 调整 `GridFrom` 对于隐藏的字段使用 `<Form.item hidden/>` 处理，并非完全过滤不处理
 

--- a/docs/reference/RestList.md
+++ b/docs/reference/RestList.md
@@ -1,0 +1,247 @@
+## RestList
+
+基于 Ant Design List 组件实现了远程加载数据的列表。
+
+**功能特性：**
+
+- 远程数据加载：基于 Ant Design List 组件实现，支持从 RESTful API 接口加载数据
+- 静态数据支持：除了远程加载，也支持直接传入静态数据源
+- 两种分页模式：支持 loadMore（加载更多）和 pagination（分页器）两种模式，pagination 优先级高于 loadMore
+- 筛选表单：通过 filterFormProps 在 List header 中渲染 GridForm 筛选表单
+- Grid 布局：支持 antd List 的 grid 配置，并校验 page_size 与 grid.column 的倍数关系
+- 灵活渲染：renderItem 直接暴露，不封装 List.Item，由调用方自行控制
+
+### 参数说明
+
+
+| 参数                  | 说明                                                                             | 类型                      | 默认值           | 版本  |
+| ------------------- | ------------------------------------------------------------------------------ | ----------------------- | ------------- | --- |
+| style               | 自定义样式                                                                          | `object`                | -             | -   |
+| className           | 自定义类名                                                                          | `string`                | -             | -   |
+| **远程数据相关**          |                                                                                |                         |               |     |
+| restful             | RESTful API 接口地址                                                               | `string`                | -             | -   |
+| reqConfig           | 请求配置，axios 请求的额外配置                                                             | `object`                | -             | -   |
+| parseOptions        | 解析 query 参数的选项，[query-string](https://www.npmjs.com/package/query-string) 的配置项 | `object`                | -             | -   |
+| baseParams          | 基础请求参数                                                                         | `object`                | -             | -   |
+| routeParams         | 路由参数                                                                           | `object`                | -             | -   |
+| forceParams         | 强制参数，会覆盖路由参数和表单参数                                                              | `object`                | -             | -   |
+| fieldPage           | 分页字段名                                                                          | `string`                | `'page'`      | -   |
+| fieldPageSize       | 每页条数字段名                                                                        | `string`                | `'page_size'` | -   |
+| defaultPageSize     | 默认每页条数                                                                         | `number`                | `20`          | -   |
+| parseRowsPath       | 解析数据行的路径                                                                       | `string`                | `'results'`   | -   |
+| parseTotalPath      | 解析总数的路径                                                                        | `string`                | `'count'`     | -   |
+| **显示和交互**           |                                                                                |                         |               |     |
+| isActive            | 是否激活，为 false 时不更新数据                                                            | `boolean`               | `true`        | -   |
+| onFiltersChange     | 筛选条件变化回调                                                                       | `function(filters)`     | -             | -   |
+| onDataSourceChange  | 数据源变化回调                                                                        | `function(dataSource)`  | -             | -   |
+| rowKey              | 行数据的 key                                                                       | `string`                | `'id'`        | -   |
+| dataSource          | 静态数据源，设置后不使用 restful                                                           | `array`                 | -             | -   |
+| renderItem          | 自定义列表项渲染函数，不封装 List.Item                                                       | `function(item, index)` | -             | -   |
+| grid                | 列表栅格配置                                                                         | `object`                | -             | -   |
+| pagination          | 分页器配置，设置后启用分页模式（优先级高于 loadMore）                                                | `boolean | object`      | -             | -   |
+| filterFormProps     | 筛选表单配置，详见 [GridForm](./GridForm.md)                                            | `object`                | -             | -   |
+| **Ant Design 原生配置** |                                                                                |                         |               |     |
+| antdListProps       | Ant Design [List](https://ant.design/components/list-cn) 组件的属性                 | `object`                | -             | -   |
+
+
+**grid 配置项：**
+
+
+| 参数     | 说明              | 类型       | 默认值 |
+| ------ | --------------- | -------- | --- |
+| gutter | 栅格间距            | `number` | -   |
+| column | 列数              | `number` | -   |
+| xs     | `<576px` 展示的列数  | `number` | -   |
+| sm     | `≥576px` 展示的列数  | `number` | -   |
+| md     | `≥768px` 展示的列数  | `number` | -   |
+| lg     | `≥992px` 展示的列数  | `number` | -   |
+| xl     | `≥1200px` 展示的列数 | `number` | -   |
+| xxl    | `≥1600px` 展示的列数 | `number` | -   |
+
+
+> **注意：** 当配置了 grid 时，`defaultPageSize`（或通过参数传入的 page_size）**必须是 grid.column 的倍数**，否则会在控制台输出 `console.error` 警告。
+
+**pagination 配置：**
+
+
+| 值            | 说明                                                                             |
+| ------------ | ------------------------------------------------------------------------------ |
+| `false` / 不传 | 使用 loadMore（加载更多）模式，数据追加累积                                                     |
+| `true`       | 启用分页器，使用默认配置（showSizeChanger、showQuickJumper、showTotal）                        |
+| `object`     | 启用分页器，支持传入 antd [Pagination](https://ant.design/components/pagination-cn) 的配置项 |
+
+
+> **优先级说明：** pagination 优先级高于 loadMore。当 pagination 启用时，loadMore 按钮不会渲染。
+
+**Ref 方法：**
+
+
+| 方法名           | 说明                     | 参数  | 返回值                     |
+| ------------- | ---------------------- | --- | ----------------------- |
+| refreshList   | 刷新列表数据                 | -   | -                       |
+| fetchMore     | 手动触发加载更多（loadMore 模式下） | -   | -                       |
+| getDataSource | 获取当前数据源                | -   | `{ dataSource, total }` |
+
+
+**静态属性：**
+
+
+| 属性              | 说明                   |
+| --------------- | -------------------- |
+| `RestList.Item` | 等同于 `List.Item`，方便使用 |
+
+
+### 使用示例
+
+**loadMore 模式（默认）：**
+
+```jsx
+import { RestList } from 'antd-restful';
+
+const LoadMoreList = () => (
+  <RestList
+    restful="/api/users/"
+    defaultPageSize={10}
+    rowKey="id"
+    filterFormProps={{
+      fields: [
+        { key: 'search', label: '搜索', type: 'input' },
+      ],
+    }}
+    renderItem={(item) => (
+      <RestList.Item>
+        <RestList.Item.Meta
+          title={item.name}
+          description={item.email}
+        />
+      </RestList.Item>
+    )}
+  />
+);
+```
+
+**pagination 模式：**
+
+```jsx
+import { RestList } from 'antd-restful';
+
+const PaginationList = () => (
+  <RestList
+    restful="/api/users/"
+    defaultPageSize={10}
+    rowKey="id"
+    pagination={{ showSizeChanger: true, pageSizeOptions: [10, 20, 50] }}
+    renderItem={(item) => (
+      <RestList.Item>
+        <RestList.Item.Meta
+          title={item.name}
+          description={item.email}
+        />
+      </RestList.Item>
+    )}
+  />
+);
+```
+
+**Grid 卡片布局：**
+
+```jsx
+import { Card, Tag } from 'antd';
+import { RestList } from 'antd-restful';
+
+// page_size=4 是 column=2 的倍数，布局正确
+const GridCardList = () => (
+  <RestList
+    restful="/api/products/"
+    defaultPageSize={4}
+    rowKey="id"
+    grid={{ gutter: 16, column: 2 }}
+    renderItem={(item) => (
+      <RestList.Item style={{ height: '100%' }}>
+        <Card style={{ height: '100%' }}>
+          <p>名称: {item.name}</p>
+          <p>价格: ¥{item.price}</p>
+        </Card>
+      </RestList.Item>
+    )}
+  />
+);
+```
+
+**配合 RouteBaseTable 使用（路由联动 + 分页）：**
+
+> RouteBaseTable + viewType="list" 一般与 pagination 配合使用，不推荐与 loadMore 结合。
+> loadMore 模式下数据会追加累积，不适合通过 URL 参数还原状态。
+
+```jsx
+import { RestList, RouteBaseTable, constants } from 'antd-restful';
+import { useLocation, useNavigate } from 'react-router';
+
+const { ViewType, FieldType } = constants;
+
+const RouteListPage = () => {
+  const location = useLocation();
+  const navigate = useNavigate();
+
+  return (
+    <RouteBaseTable
+      viewType={ViewType.LIST}
+      location={location}
+      onSearchChange={(search) => {
+        navigate(`${location.pathname}${search}`);
+      }}
+      restProps={{
+        restful: '/api/users/',
+        defaultPageSize: 10,
+        rowKey: 'id',
+        pagination: true,
+        filterFormProps: {
+          fields: [
+            { key: 'search', label: '搜索', type: FieldType.INPUT },
+          ],
+        },
+        renderItem: (item) => (
+          <RestList.Item>
+            <RestList.Item.Meta
+              title={item.name}
+              description={item.email}
+            />
+          </RestList.Item>
+        ),
+      }}
+    />
+  );
+};
+```
+
+### 两种分页模式对比
+
+
+| 特性                | loadMore（默认）        | pagination                |
+| ----------------- | ------------------- | ------------------------- |
+| 数据管理              | 数据追加累积，越来越多         | 每次切页替换当前数据                |
+| 适用场景              | 信息流、瀑布流、内容发现        | 精确导航、搜索结果、管理列表            |
+| 路由联动              | 不推荐，数据累积无法通过 URL 还原 | 推荐，page/pageSize 可映射到 URL |
+| 配合 RouteBaseTable | 不推荐                 | 推荐                        |
+| 用户感知              | "加载更多"按钮            | 页码导航器                     |
+
+
+### 常见问题
+
+1. **grid 布局最后一行不完整**
+
+当 page_size 不是 grid.column 的倍数时，最后一行的卡片数量不一致，导致布局不对齐。组件会在控制台输出 error 提示：
+
+```
+[RestList] restful="api/users/" page_size=3 必须是 grid.column=2 的倍数，当前不满足，会导致列表布局不对齐。
+```
+
+确保 `defaultPageSize`（或 `baseParams.page_size`）是 `grid.column` 的倍数即可。
+
+1. **pagination 和 loadMore 能同时使用吗？**
+
+antd List 技术上允许同时传递 `loadMore` 和 `pagination`，但二者的数据管理逻辑冲突（一个追加累积，一个翻页替换），在 RestList 中做了互斥处理：**pagination 优先级高于 loadMore**，当 pagination 启用时不会渲染 loadMore 按钮。
+
+1. **Grid 卡片高度不一致**
+
+在使用 grid 布局时，建议给 `RestList.Item` 和内部的 `Card` 都设置 `style={{ height: '100%' }}`，确保同一行卡片高度对齐。

--- a/docs/reference/RestList.md
+++ b/docs/reference/RestList.md
@@ -44,9 +44,21 @@
 | parseTotalPath | 解析总数的路径 | `string` | `'count'` | - | - |
 | **控制与筛选** | | | | | |
 | isActive | 是否激活，为 false 时不请求数据 | `boolean` | `true` | - | - |
-| filterFormProps | 筛选表单配置，详见 [GridForm](./GridForm.md) | `object` | - | 内部生成 List `header` | - |
+| filterFormProps | 筛选表单配置，详见 [GridForm](./GridForm.md)。筛选表单渲染在 List 上方（独立于 List 组件外部） | `object` | - | - | - |
+| loadMoreProps | loadMore 加载更多区域的自定义配置，详见下方 loadMoreProps 配置项 | `object` | - | - | - |
 | **Ant Design 原生配置** | | | | | |
-| antdListProps | Ant Design [List](https://ant.design/components/list-cn) 的其余属性。注意 `loading` / `header` / `loadMore` / `pagination` / `dataSource` / `renderItem` / `rowKey` 由 RestList 内部管理，通过此属性设置会被覆盖 | `object` | - | 透传剩余属性 | - |
+| antdListProps | Ant Design [List](https://ant.design/components/list-cn) 的其余属性。注意 `loading` / `loadMore` / `pagination` / `dataSource` / `renderItem` / `rowKey` 由 RestList 内部管理，通过此属性设置会被覆盖 | `object` | - | 透传剩余属性 | - |
+| antdSpaceProps | 外层容器 Ant Design [Space](https://ant.design/components/space-cn) 组件的属性，用于控制筛选表单与列表之间的间距等样式 | `object` | - | 透传 Space 属性 | - |
+
+
+**loadMoreProps 配置项：**
+
+
+| 参数 | 说明 | 类型 | 默认值 |
+| --- | --- | --- | --- |
+| style | 自定义加载更多区域的容器样式，会与默认样式合并 | `object` | `{ textAlign: 'center', marginTop: 12, marginBottom: 12 }` |
+| text | 自定义按钮文案 | `string` | `'加载更多'` |
+| render | 完全自定义渲染函数，设置后 style 和 text 不生效 | `function(fetchMore, loadingMore, hasMore)` | - |
 
 
 **grid 配置项：**

--- a/docs/reference/RestList.md
+++ b/docs/reference/RestList.md
@@ -14,34 +14,39 @@
 ### 参数说明
 
 
-| 参数                  | 说明                                                                             | 类型                      | 默认值           | 版本  |
-| ------------------- | ------------------------------------------------------------------------------ | ----------------------- | ------------- | --- |
-| style               | 自定义样式                                                                          | `object`                | -             | -   |
-| className           | 自定义类名                                                                          | `string`                | -             | -   |
-| **远程数据相关**          |                                                                                |                         |               |     |
-| restful             | RESTful API 接口地址                                                               | `string`                | -             | -   |
-| reqConfig           | 请求配置，axios 请求的额外配置                                                             | `object`                | -             | -   |
-| parseOptions        | 解析 query 参数的选项，[query-string](https://www.npmjs.com/package/query-string) 的配置项 | `object`                | -             | -   |
-| baseParams          | 基础请求参数                                                                         | `object`                | -             | -   |
-| routeParams         | 路由参数                                                                           | `object`                | -             | -   |
-| forceParams         | 强制参数，会覆盖路由参数和表单参数                                                              | `object`                | -             | -   |
-| fieldPage           | 分页字段名                                                                          | `string`                | `'page'`      | -   |
-| fieldPageSize       | 每页条数字段名                                                                        | `string`                | `'page_size'` | -   |
-| defaultPageSize     | 默认每页条数                                                                         | `number`                | `20`          | -   |
-| parseRowsPath       | 解析数据行的路径                                                                       | `string`                | `'results'`   | -   |
-| parseTotalPath      | 解析总数的路径                                                                        | `string`                | `'count'`     | -   |
-| **显示和交互**           |                                                                                |                         |               |     |
-| isActive            | 是否激活，为 false 时不更新数据                                                            | `boolean`               | `true`        | -   |
-| onFiltersChange     | 筛选条件变化回调                                                                       | `function(filters)`     | -             | -   |
-| onDataSourceChange  | 数据源变化回调                                                                        | `function(dataSource)`  | -             | -   |
-| rowKey              | 行数据的 key                                                                       | `string`                | `'id'`        | -   |
-| dataSource          | 静态数据源，设置后不使用 restful                                                           | `array`                 | -             | -   |
-| renderItem          | 自定义列表项渲染函数，不封装 List.Item                                                       | `function(item, index)` | -             | -   |
-| grid                | 列表栅格配置                                                                         | `object`                | -             | -   |
-| pagination          | 分页器配置，设置后启用分页模式（优先级高于 loadMore）                                                | `boolean | object`      | -             | -   |
-| filterFormProps     | 筛选表单配置，详见 [GridForm](./GridForm.md)                                            | `object`                | -             | -   |
-| **Ant Design 原生配置** |                                                                                |                         |               |     |
-| antdListProps       | Ant Design [List](https://ant.design/components/list-cn) 组件的属性                 | `object`                | -             | -   |
+| 参数 | 说明 | 类型 | 默认值 | antd 覆盖说明 | 版本 |
+| --- | --- | --- | --- | --- | --- |
+| **通用属性** | | | | | |
+| style | 自定义样式 | `object` | - | 透传 List `style` | - |
+| className | 自定义类名 | `string` | - | 透传 List `className` | - |
+| **数据与渲染** | | | | | |
+| dataSource | 静态数据源，设置后不使用 restful 远程加载 | `array` | - | 覆盖 List `dataSource`，由内部管理 | - |
+| renderItem | 自定义列表项渲染函数，不封装 List.Item | `function(item, index)` | - | 透传 List `renderItem` | - |
+| rowKey | 行数据的唯一标识字段名 | `string` | `'id'` | 透传 List `rowKey` | - |
+| **分页与布局** | | | | | |
+| pagination | 分页器配置，设置后启用分页模式（优先级高于 loadMore） | `boolean \| object` | - | 覆盖 List `pagination`，内部封装分页逻辑 | - |
+| grid | 列表栅格配置，详见下方 grid 配置项 | `object` | - | 透传 List `grid`，增加 column 倍数校验 | - |
+| **回调函数** | | | | | |
+| onDataSourceChange | 数据源变化回调 | `function({ dataSource, total })` | - | - | - |
+| onFiltersChange | 筛选条件变化回调 | `function(filters)` | - | - | - |
+| **远程数据配置** | | | | | |
+| restful | RESTful API 接口地址 | `string` | - | - | - |
+| reqConfig | 请求配置，axios 请求的额外配置 | `object` | - | - | - |
+| parseOptions | 解析 query 参数的选项，[query-string](https://www.npmjs.com/package/query-string) 的配置项 | `object` | - | - | - |
+| baseParams | 基础请求参数 | `object` | - | - | - |
+| routeParams | 路由参数 | `object` | - | - | - |
+| forceParams | 强制参数，会覆盖路由参数和表单参数 | `object` | - | - | - |
+| **请求字段配置** | | | | | |
+| fieldPage | 分页字段名 | `string` | `'page'` | - | - |
+| fieldPageSize | 每页条数字段名 | `string` | `'page_size'` | - | - |
+| defaultPageSize | 默认每页条数 | `number` | `20` | - | - |
+| parseRowsPath | 解析数据行的路径 | `string` | `'results'` | - | - |
+| parseTotalPath | 解析总数的路径 | `string` | `'count'` | - | - |
+| **控制与筛选** | | | | | |
+| isActive | 是否激活，为 false 时不请求数据 | `boolean` | `true` | - | - |
+| filterFormProps | 筛选表单配置，详见 [GridForm](./GridForm.md) | `object` | - | 内部生成 List `header` | - |
+| **Ant Design 原生配置** | | | | | |
+| antdListProps | Ant Design [List](https://ant.design/components/list-cn) 的其余属性。注意 `loading` / `header` / `loadMore` / `pagination` / `dataSource` / `renderItem` / `rowKey` 由 RestList 内部管理，通过此属性设置会被覆盖 | `object` | - | 透传剩余属性 | - |
 
 
 **grid 配置项：**

--- a/docs/reference/hooks.md
+++ b/docs/reference/hooks.md
@@ -275,64 +275,7 @@ function MyComponent() {
 
 ### useSafeRequest
 
-提供安全的 HTTP 请求功能，支持请求取消和防抖。
-
-**签名：**
-```javascript
-const [makeRequest] = useSafeRequest()
-```
-
-**返回值：**
-- `makeRequest` (function): 请求函数，接受配置选项，返回包含各种 HTTP 方法的对象
-
-**特性：**
-- 自动处理组件卸载后的请求取消
-- 支持请求防抖
-- 支持请求去重
-- 提供完整的 HTTP 方法（get, post, put, patch, delete 等）
-
-**使用示例：**
-```javascript
-import { useSafeRequest } from 'src/requests';
-
-function MyComponent() {
-  const [makeRequest] = useSafeRequest();
-  const [data, setData] = useState(null);
-  const [loading, setLoading] = useState(false);
-
-  const fetchData = async () => {
-    setLoading(true);
-    try {
-      const response = await makeRequest({ delay: 300, key: 'fetch-data' })
-        .get('/api/data');
-      setData(response.data);
-    } catch (error) {
-      console.error('Fetch failed:', error);
-    } finally {
-      setLoading(false);
-    }
-  };
-
-  const createItem = async (itemData) => {
-    try {
-      const response = await makeRequest({ key: 'create-item' })
-        .post('/api/items', itemData);
-      console.log('Item created:', response.data);
-    } catch (error) {
-      console.error('Create failed:', error);
-    }
-  };
-
-  return (
-    <div>
-      <button onClick={fetchData} disabled={loading}>
-        {loading ? 'Loading...' : 'Fetch Data'}
-      </button>
-      {data && <pre>{JSON.stringify(data, null, 2)}</pre>}
-    </div>
-  );
-}
-```
+> 已迁移至 [请求模块文档](./requests.md#usesaferequest)，包含完整的 API 说明、防抖行为、请求去重及拦截器用法。
 
 ## 最佳实践
 
@@ -352,14 +295,12 @@ function MyComponent() {
 - 使用 `useDictState` 管理相关的多个状态值
 
 ### 4. 请求 Hooks 使用建议
-- 使用 `useSafeRequest` 替代直接的 axios 调用
-- 合理设置请求的 key 和 delay 参数
-- 在组件卸载时自动取消未完成的请求
+- 详见 [请求模块文档](./requests.md)
 
 ## 注意事项
 
 1. **存储限制**：localStorage 和 sessionStorage 有存储大小限制（通常为 5-10MB）
 2. **序列化**：存储 Hooks 会自动进行 JSON 序列化，不支持存储函数等特殊类型
 3. **性能考虑**：`useDeepCompareMemoize` 的深度比较可能影响性能，避免在频繁更新的场景中使用
-4. **请求取消**：`useSafeRequest` 会自动处理请求取消，但建议在组件卸载前手动取消重要的请求
+4. **请求取消**：详见 [请求模块文档](./requests.md)
 5. **定时器清理**：虽然 Hooks 会自动清理定时器，但在复杂场景下建议手动控制定时器的生命周期

--- a/docs/reference/requests.md
+++ b/docs/reference/requests.md
@@ -1,0 +1,328 @@
+# 请求模块 (requests)
+
+本文档介绍 antd-restful 的 HTTP 请求模块，基于 [axios](https://axios-http.com/) 封装，提供统一的请求实例、拦截器机制、错误通知、请求取消与防抖等能力。
+
+## useSafeRequest
+
+React Hook，提供安全的 HTTP 请求功能，支持请求取消和防抖。组件卸载时自动取消所有未完成的请求。
+
+**签名：**
+
+```javascript
+const [makeRequest] = useSafeRequest()
+```
+
+**返回值：**
+
+- `makeRequest` (function): 请求工厂函数，接受配置选项，返回包含各种 HTTP 方法的对象
+
+**配置选项：**
+
+- `key` (string, 可选): 请求标识。不传时每次调用自动生成递增的数字 ID，请求完成后自动清理；传入固定字符串时，相同 key 的请求会自动取消前一次未完成的请求，适用于去重场景。**注意**：不允许传入数字类型的 key，数字会被自动加上 `key-` 前缀以避免与内部自增 ID 冲突
+- `delay` (number): 防抖延迟（毫秒），默认 `0`（不防抖）。必须搭配 `key` 使用——防抖依赖固定 key 来识别"同一类请求"，从而取消前一次并延迟发送。首次调用立即发送，后续调用在 delay 时间内如有新调用则取消前一次
+
+**支持的 HTTP 方法：**
+
+- `get(url, config)`
+- `head(url, config)`
+- `options(url, config)`
+- `post(url, data, config)`
+- `put(url, data, config)`
+- `patch(url, data, config)`
+- `delete(url, data, config)`
+
+**使用示例：**
+
+最常见的用法——不传 `key`，每次调用自动分配独立 ID，组件卸载时统一取消：
+
+```javascript
+import { useSafeRequest } from 'src/requests';
+
+function MyComponent() {
+  const [makeRequest] = useSafeRequest();
+  const [data, setData] = useState(null);
+  const [loading, setLoading] = useState(false);
+
+  const fetchData = async () => {
+    setLoading(true);
+    try {
+      const response = await makeRequest({ delay: 300, key: 'fetch-data' })
+        .get('/api/data');
+      setData(response.data);
+    } catch (error) {
+      console.error('Fetch failed:', error);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const createItem = async (itemData) => {
+    try {
+      const response = await makeRequest().post('/api/items', itemData);
+      console.log('Item created:', response.data);
+    } catch (error) {
+      console.error('Create failed:', error);
+    }
+  };
+
+  return (
+    <div>
+      <button onClick={fetchData} disabled={loading}>
+        {loading ? 'Loading...' : 'Fetch Data'}
+      </button>
+      {data && <pre>{JSON.stringify(data, null, 2)}</pre>}
+    </div>
+  );
+}
+```
+
+需要防抖或去重时，传入 `delay` 和 `key`：
+
+```javascript
+import { useSafeRequest } from 'src/requests';
+
+function SearchComponent() {
+  const [makeRequest] = useSafeRequest();
+  const [results, setResults] = useState([]);
+
+  const onSearch = (keyword) => {
+    makeRequest({ delay: 300, key: 'search' })
+      .get('/api/search', { params: { q: keyword } })
+      .then((resp) => setResults(resp.data));
+  };
+
+  return <Input.Search onChange={(e) => onSearch(e.target.value)} />;
+}
+```
+
+### 防抖行为
+
+当设置 `delay > 0` 时，`makeRequest` 具备防抖能力：
+
+- 首次调用立即发送请求
+- 在 `delay` 时间窗口内的后续调用会取消前次请求，等待 delay 后发送
+- 超过 `5 * delay` 未发起新请求，则下一次视为"首次调用"立即发送
+
+```javascript
+const [makeRequest] = useSafeRequest();
+
+// 搜索框防抖：用户停止输入 500ms 后发送请求
+const onSearch = (keyword) => {
+  makeRequest({ delay: 500, key: 'search' })
+    .get('/api/search', { params: { q: keyword } })
+    .then((resp) => setResults(resp.data));
+};
+```
+
+### 请求去重
+
+通过 `key` 实现同类请求去重——相同 key 的新请求会自动取消上一次未完成的请求：
+
+```javascript
+const [makeRequest] = useSafeRequest();
+
+// 切换 tab 时，前一个 tab 的请求自动取消
+const onTabChange = (tabKey) => {
+  makeRequest({ key: 'tab-data' })
+    .get(`/api/tab/${tabKey}`)
+    .then((resp) => setTabData(resp.data));
+};
+```
+
+## Axios 实例
+
+模块默认导出一个预配置的 axios 实例，可直接用于所有标准的 axios 方法：
+
+```javascript
+import request from 'src/requests';
+
+const response = await request.get('/api/users');
+```
+
+**默认配置：**
+
+- `timeout`: 10000ms
+- `Content-Type`: `application/json`
+- `paramsSerializer`: 使用 `globalConfig.queryStringify` 序列化查询参数
+
+### globalConfig
+
+请求实例的 `paramsSerializer` 依赖全局配置 `globalConfig`，默认使用 [query-string](https://github.com/sindresorhus/query-string) 库，预设 `arrayFormat: "comma"` 格式。
+
+可以通过 `setGlobalConfig` 替换序列化和解析逻辑：
+
+```javascript
+import antdRestful from 'antd-restful';
+const { setGlobalConfig } = antdRestful;
+
+import Qs from 'qs';
+setGlobalConfig({
+  queryStringify: (params) => Qs.stringify(params, { arrayFormat: 'brackets' }),
+  queryParse: (string) => Qs.parse(string, { arrayFormat: 'brackets' }),
+});
+```
+
+`globalConfig` 支持的字段：
+
+| 字段 | 类型 | 默认行为 | 说明 |
+|------|------|----------|------|
+| `queryStringify` | `(params, options?) => string` | `query-string.stringify`，`arrayFormat: "comma"` | 将对象序列化为 URL 查询字符串 |
+| `queryParse` | `(string, options?) => object` | `query-string.parse`，`arrayFormat: "comma"` | 将 URL 查询字符串解析为对象 |
+
+该配置影响所有通过 axios 实例发出的请求的查询参数序列化，同时也被 `RouteBaseTable` 等组件用于 URL 参数的解析与生成。
+
+## 拦截器
+
+### 内置请求拦截器
+
+模块内置了一个请求拦截器，自动为写操作（POST / PUT / PATCH / DELETE）附加 Django CSRF Token：
+
+```javascript
+import { reqInterceptor } from 'src/requests';
+```
+
+Token 获取顺序：
+
+1. 从页面中查找 `<input name="csrfmiddlewaretoken">` 元素
+2. 回退到 `csrftoken` Cookie
+
+### 内置响应拦截器
+
+模块内置了一个响应拦截器，统一处理请求错误：
+
+```javascript
+import { resInterceptor } from 'src/requests';
+```
+
+默认行为：
+
+- 非 `CanceledError` 的错误会通过 `notification.error` 弹出通知
+- 401 / 403 / 404 错误通过 `key` 去重，避免多次弹出
+- 可通过 `config.disableNotiError = true` 关闭单次请求的错误通知
+
+### 自定义拦截器
+
+你可以在内置拦截器的基础上添加自定义拦截器，或者移除内置拦截器后完全自定义。
+
+#### 添加自定义拦截器
+
+```javascript
+import request, { reqInterceptor, resInterceptor } from 'src/requests';
+
+// 添加请求拦截器：注入 Authorization 头
+request.interceptors.request.use((config) => {
+  const token = localStorage.getItem('access_token');
+  if (token) {
+    config.headers.Authorization = `Bearer ${token}`;
+  }
+  return config;
+});
+
+// 添加响应拦截器：处理 401 跳转登录
+request.interceptors.response.use(
+  (response) => response,
+  (error) => {
+    if (error.response?.status === 401) {
+      localStorage.removeItem('access_token');
+      window.location.href = '/login';
+      return new Promise(() => {}); // 阻止后续 then/catch 执行
+    }
+    return Promise.reject(error);
+  }
+);
+```
+
+#### 移除内置拦截器
+
+如果内置拦截器不满足需求，可以移除后替换为自定义实现：
+
+```javascript
+import request, { reqInterceptor, resInterceptor } from 'src/requests';
+
+// 移除内置拦截器
+request.interceptors.request.eject(reqInterceptor);
+request.interceptors.response.eject(resInterceptor);
+
+// 注册自定义拦截器
+request.interceptors.response.use(
+  (response) => response,
+  (error) => {
+    const status = error.response?.status;
+    switch (status) {
+      case 401:
+        window.location.href = '/login';
+        return new Promise(() => {});
+      case 403:
+        window.location.href = '/403';
+        return new Promise(() => {});
+      default:
+        return Promise.reject(error);
+    }
+  }
+);
+```
+
+#### 禁用单次请求的错误通知
+
+```javascript
+import request from 'src/requests';
+
+// disableNotiError 会阻止内置响应拦截器弹出通知
+request.get('/api/silent', { disableNotiError: true });
+```
+
+## makeSafeRequest
+
+非 Hook 版本的安全请求工厂，适用于非 React 组件的场景。使用方式与 `useSafeRequest` 返回的 `makeRequest` 相同，但需要手动调用 `unmount()` 释放资源。
+
+```javascript
+import { makeSafeRequest } from 'src/requests';
+
+const makeRequest = makeSafeRequest();
+
+// 发起请求
+makeRequest({ key: 'my-request' }).get('/api/data');
+
+// 不再需要时，手动释放
+makeRequest.unmount();
+```
+
+## 工具函数
+
+### formatRequestError
+
+格式化 axios 错误对象为通知友好的格式。
+
+```javascript
+import { formatRequestError } from 'src/requests';
+
+const { message, description } = formatRequestError(error);
+// message: "HttpError(404)" 或 "未知错误"
+// description: 包含请求方法、URL 和响应内容的详细信息
+```
+
+### getCookie
+
+从 `document.cookie` 中读取指定名称的 Cookie 值。
+
+```javascript
+import { getCookie } from 'src/requests';
+
+const token = getCookie('csrftoken');
+```
+
+## 导出总览
+
+
+| 导出名                  | 类型       | 说明                     |
+| -------------------- | -------- | ---------------------- |
+| `default`            | axios 实例 | 预配置的 axios 实例          |
+| `reqInterceptor`     | number   | 内置请求拦截器 ID，可用于 `eject` |
+| `resInterceptor`     | number   | 内置响应拦截器 ID，可用于 `eject` |
+| `useSafeRequest`     | Hook     | React Hook，组件级安全请求     |
+| `makeSafeRequest`    | function | 非 Hook 版安全请求工厂         |
+| `formatRequestError` | function | 错误格式化工具                |
+| `getCookie`          | function | Cookie 读取工具            |
+| `AbortablePromise`   | class    | 可中止的 Promise 实现        |
+
+

--- a/docs/reference/requests.md
+++ b/docs/reference/requests.md
@@ -1,6 +1,21 @@
-# 请求模块 (requests)
+# 请求模块 (apiTools)
 
 本文档介绍 antd-restful 的 HTTP 请求模块，基于 [axios](https://axios-http.com/) 封装，提供统一的请求实例、拦截器机制、错误通知、请求取消与防抖等能力。
+
+**导入方式：**
+
+```javascript
+import antdRestful from 'antd-restful';
+
+// request 实例（axios）直接从顶层获取
+const { request } = antdRestful;
+
+// 其他工具函数和 Hook 通过 apiTools 命名空间获取
+const { apiTools: { useSafeRequest, makeSafeRequest, formatRequestError, getCookie } } = antdRestful;
+
+// 拦截器 ID 也在 apiTools 下
+const { apiTools: { reqInterceptor, resInterceptor } } = antdRestful;
+```
 
 ## useSafeRequest
 
@@ -36,7 +51,8 @@ const [makeRequest] = useSafeRequest()
 最常见的用法——不传 `key`，每次调用自动分配独立 ID，组件卸载时统一取消：
 
 ```javascript
-import { useSafeRequest } from 'src/requests';
+import antdRestful from 'antd-restful';
+const { apiTools: { useSafeRequest } } = antdRestful;
 
 function MyComponent() {
   const [makeRequest] = useSafeRequest();
@@ -79,7 +95,8 @@ function MyComponent() {
 需要防抖或去重时，传入 `delay` 和 `key`：
 
 ```javascript
-import { useSafeRequest } from 'src/requests';
+import antdRestful from 'antd-restful';
+const { apiTools: { useSafeRequest } } = antdRestful;
 
 function SearchComponent() {
   const [makeRequest] = useSafeRequest();
@@ -134,7 +151,8 @@ const onTabChange = (tabKey) => {
 模块默认导出一个预配置的 axios 实例，可直接用于所有标准的 axios 方法：
 
 ```javascript
-import request from 'src/requests';
+import antdRestful from 'antd-restful';
+const { request } = antdRestful;
 
 const response = await request.get('/api/users');
 ```
@@ -178,7 +196,7 @@ setGlobalConfig({
 模块内置了一个请求拦截器，自动为写操作（POST / PUT / PATCH / DELETE）附加 Django CSRF Token：
 
 ```javascript
-import { reqInterceptor } from 'src/requests';
+const { apiTools: { reqInterceptor } } = antdRestful;
 ```
 
 Token 获取顺序：
@@ -191,7 +209,7 @@ Token 获取顺序：
 模块内置了一个响应拦截器，统一处理请求错误：
 
 ```javascript
-import { resInterceptor } from 'src/requests';
+const { apiTools: { resInterceptor } } = antdRestful;
 ```
 
 默认行为：
@@ -207,7 +225,8 @@ import { resInterceptor } from 'src/requests';
 #### 添加自定义拦截器
 
 ```javascript
-import request, { reqInterceptor, resInterceptor } from 'src/requests';
+import antdRestful from 'antd-restful';
+const { request, apiTools: { reqInterceptor, resInterceptor } } = antdRestful;
 
 // 添加请求拦截器：注入 Authorization 头
 request.interceptors.request.use((config) => {
@@ -237,7 +256,8 @@ request.interceptors.response.use(
 如果内置拦截器不满足需求，可以移除后替换为自定义实现：
 
 ```javascript
-import request, { reqInterceptor, resInterceptor } from 'src/requests';
+import antdRestful from 'antd-restful';
+const { request, apiTools: { reqInterceptor, resInterceptor } } = antdRestful;
 
 // 移除内置拦截器
 request.interceptors.request.eject(reqInterceptor);
@@ -265,7 +285,7 @@ request.interceptors.response.use(
 #### 禁用单次请求的错误通知
 
 ```javascript
-import request from 'src/requests';
+const { request } = antdRestful;
 
 // disableNotiError 会阻止内置响应拦截器弹出通知
 request.get('/api/silent', { disableNotiError: true });
@@ -276,7 +296,8 @@ request.get('/api/silent', { disableNotiError: true });
 非 Hook 版本的安全请求工厂，适用于非 React 组件的场景。使用方式与 `useSafeRequest` 返回的 `makeRequest` 相同，但需要手动调用 `unmount()` 释放资源。
 
 ```javascript
-import { makeSafeRequest } from 'src/requests';
+import antdRestful from 'antd-restful';
+const { apiTools: { makeSafeRequest } } = antdRestful;
 
 const makeRequest = makeSafeRequest();
 
@@ -294,7 +315,7 @@ makeRequest.unmount();
 格式化 axios 错误对象为通知友好的格式。
 
 ```javascript
-import { formatRequestError } from 'src/requests';
+const { apiTools: { formatRequestError } } = antdRestful;
 
 const { message, description } = formatRequestError(error);
 // message: "HttpError(404)" 或 "未知错误"
@@ -306,23 +327,22 @@ const { message, description } = formatRequestError(error);
 从 `document.cookie` 中读取指定名称的 Cookie 值。
 
 ```javascript
-import { getCookie } from 'src/requests';
+const { apiTools: { getCookie } } = antdRestful;
 
 const token = getCookie('csrftoken');
 ```
 
 ## 导出总览
 
-
-| 导出名                  | 类型       | 说明                     |
-| -------------------- | -------- | ---------------------- |
-| `default`            | axios 实例 | 预配置的 axios 实例          |
-| `reqInterceptor`     | number   | 内置请求拦截器 ID，可用于 `eject` |
-| `resInterceptor`     | number   | 内置响应拦截器 ID，可用于 `eject` |
-| `useSafeRequest`     | Hook     | React Hook，组件级安全请求     |
-| `makeSafeRequest`    | function | 非 Hook 版安全请求工厂         |
-| `formatRequestError` | function | 错误格式化工具                |
-| `getCookie`          | function | Cookie 读取工具            |
-| `AbortablePromise`   | class    | 可中止的 Promise 实现        |
+| 访问路径 | 类型 | 说明 |
+|------|------|------|
+| `antdRestful.request` | axios 实例 | 预配置的 axios 实例 |
+| `antdRestful.apiTools.reqInterceptor` | number | 内置请求拦截器 ID，可用于 `eject` |
+| `antdRestful.apiTools.resInterceptor` | number | 内置响应拦截器 ID，可用于 `eject` |
+| `antdRestful.apiTools.useSafeRequest` | Hook | React Hook，组件级安全请求 |
+| `antdRestful.apiTools.makeSafeRequest` | function | 非 Hook 版安全请求工厂 |
+| `antdRestful.apiTools.formatRequestError` | function | 错误格式化工具 |
+| `antdRestful.apiTools.getCookie` | function | Cookie 读取工具 |
+| `antdRestful.apiTools.AbortablePromise` | class | 可中止的 Promise 实现 |
 
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "antd-restful",
-  "version": "0.2.4",
+  "version": "0.3.0",
   "author": "SkylerHu",
   "private": false,
   "main": "dist/index.js",

--- a/package.json
+++ b/package.json
@@ -111,13 +111,13 @@
     "resttable",
     "restselect"
   ],
-  "homepage": "https://github.com/SkylerHu/antd-restful",
+  "homepage": "https://github.com/skylerhu/antd-restful",
   "repository": {
     "type": "git",
-    "url": "git@github.com:SkylerHu/antd-restful.git"
+    "url": "git@github.com:skylerhu/antd-restful.git"
   },
   "bugs": {
-    "url": "https://github.com/SkylerHu/antd-restful/issues"
+    "url": "https://github.com/skylerhu/antd-restful/issues"
   },
   "license": "MIT"
 }

--- a/src/common/constants.js
+++ b/src/common/constants.js
@@ -29,6 +29,11 @@ export const FieldType = new Enum([
   { key: "UPLOAD", value: "upload", label: "上传" },
 ]);
 
+export const ViewType = new Enum([
+  { key: "TABLE", value: "table", label: "表格" },
+  { key: "LIST", value: "list", label: "列表" },
+]);
+
 export const READ_ONLY_CLASS = "cls-antd-restful-readonly";
 
 export const FilterType = new Enum([

--- a/src/components/RestList.jsx
+++ b/src/components/RestList.jsx
@@ -1,0 +1,450 @@
+import React, { forwardRef, useCallback, useEffect, useImperativeHandle, useMemo, useRef, useState } from "react";
+import PropTypes from "prop-types";
+import { Button, List, Spin } from "antd";
+import { dequal as deepEqual } from "dequal";
+import { DEFAULT_PAGE, DEFAULT_PAGE_SIZE, DEFAULT_ROWS_PATH, FieldType } from "src/common/constants";
+import { clearEmptyValue, findDataByPath, genColumnKey, genFields, handleFormValues } from "src/common/parser";
+import { isArray, isEmpty, isFunction } from "src/common/typeTools";
+import GridForm from "src/components/GridForm";
+import globalConfig from "src/config";
+import { useDeepCompareMemoize, useDictState } from "src/hooks/index";
+import { useSafeRequest } from "src/requests";
+
+const REFRESH_COUNTER_KEY = "____list_refresh";
+
+const RestList = forwardRef(
+  (
+    {
+      style,
+      className,
+
+      restful,
+      reqConfig,
+      parseOptions,
+      baseParams,
+      routeParams,
+      forceParams,
+      fieldPage = "page",
+      fieldPageSize = "page_size",
+      defaultPageSize = DEFAULT_PAGE_SIZE,
+      parseRowsPath = DEFAULT_ROWS_PATH,
+      parseTotalPath = "count",
+      isActive = true,
+      onDataSourceChange,
+      onFiltersChange,
+
+      rowKey = "id",
+      dataSource,
+      renderItem,
+      grid,
+      pagination,
+      antdListProps,
+      filterFormProps,
+    },
+    ref
+  ) => {
+    const [makeRequest] = useSafeRequest();
+    const reqConfigRef = useRef(reqConfig);
+    const memParseOptions = useDeepCompareMemoize(parseOptions);
+
+    const usePagination = !!pagination;
+
+    const [loading, setLoading] = useState(false);
+    const [loadingMore, setLoadingMore] = useState(false);
+
+    const [innerData, setInnerData] = useState({
+      total: 0,
+      dataSource: [],
+    });
+
+    const filterFormRef = useRef();
+
+    const memBaseParams = useDeepCompareMemoize(baseParams);
+    const memRouteParams = useDeepCompareMemoize(routeParams);
+    const memForceParams = useDeepCompareMemoize(forceParams);
+    const [innerFilters, setInnerFilters] = useState({});
+
+    const [filterFieldKeys] = useState([]);
+    const formFiltersRef = useRef({});
+    const [filterState, setFilterState] = useDictState({
+      formFilters: {},
+      paginationFilters: {},
+    });
+
+    const filterFields = useMemo(() => {
+      const fields = genFields(filterFormProps?.fields, filterFieldKeys);
+      fields?.forEach((field) => {
+        if ([FieldType.NUMBER_RANGE, FieldType.DATE_RANGE_PICKER].includes(field.type)) {
+          field.antdFieldProps = {
+            defaultEmptyValue: "",
+            ...field.antdFieldProps,
+          };
+        }
+      });
+      return fields;
+    }, [filterFieldKeys, filterFormProps?.fields]);
+
+    useEffect(() => {
+      if (isArray(dataSource)) {
+        setInnerData((oldV) => {
+          const newV = { dataSource, total: dataSource?.length };
+          return deepEqual(oldV, newV) ? oldV : newV;
+        });
+      }
+    }, [dataSource]);
+
+    useEffect(() => {
+      if (isFunction(onDataSourceChange)) {
+        onDataSourceChange(innerData);
+      }
+    }, [innerData, onDataSourceChange]);
+
+    const pageSize = useMemo(() => {
+      return parseInt(innerFilters[fieldPageSize] || defaultPageSize);
+    }, [innerFilters, fieldPageSize, defaultPageSize]);
+
+    useEffect(() => {
+      const column = grid?.column;
+      if (column && column > 0 && pageSize % column !== 0) {
+        console.error( // eslint-disable-line no-console
+          `[RestList] restful="${restful}" page_size=${pageSize} 必须是 grid.column=${column} 的倍数，当前不满足，会导致列表布局不对齐。`
+        );
+      }
+    }, [grid?.column, pageSize, restful]);
+
+    useEffect(() => {
+      const oldV = formFiltersRef.current;
+      const values = {};
+      filterFields?.forEach((field) => {
+        let v = undefined;
+        v = oldV ? oldV[field.key] : undefined;
+        if (v !== null && v !== "") {
+          v = memRouteParams ? memRouteParams[field.key] : undefined;
+          if (v === undefined) {
+            v = memBaseParams ? memBaseParams[field.key] : undefined;
+          }
+        }
+        values[field.key] = v;
+      });
+      delete values[fieldPage];
+      delete values[fieldPageSize];
+
+      let newV = handleFormValues(values, filterFields);
+      if (!deepEqual(oldV, newV)) {
+        setFilterState({ formFilters: newV });
+      }
+    }, [memRouteParams, memBaseParams, filterFields, fieldPage, fieldPageSize, setFilterState]);
+
+    useEffect(() => {
+      const formFilters = filterState.formFilters;
+      filterFormRef.current?.getFormInstance()?.setFieldsValueAndActiveKey(formFilters);
+    }, [filterState.formFilters]);
+
+    useEffect(() => {
+      setInnerFilters((oldV) => {
+        let newV = {
+          ...memBaseParams,
+          ...memRouteParams,
+          ...filterState.paginationFilters,
+          ...filterState.formFilters,
+          ...memForceParams,
+        };
+        newV[fieldPage] = parseInt(newV[fieldPage]) || DEFAULT_PAGE;
+        newV[fieldPageSize] = parseInt(newV[fieldPageSize]) || defaultPageSize;
+        newV = clearEmptyValue(newV);
+        if (deepEqual(oldV, newV)) {
+          return oldV;
+        }
+        return newV;
+      });
+    }, [fieldPage, fieldPageSize, defaultPageSize, memBaseParams, memRouteParams, memForceParams, filterState]);
+
+    useEffect(() => {
+      if (!innerFilters[fieldPage] || !innerFilters[fieldPageSize]) {
+        return;
+      }
+      if (isFunction(onFiltersChange)) {
+        const filters = { ...innerFilters };
+        delete filters[REFRESH_COUNTER_KEY];
+        if (filters[fieldPage] === DEFAULT_PAGE) {
+          delete filters[fieldPage];
+        }
+        if (memBaseParams && memBaseParams[fieldPageSize]) {
+          if (filters[fieldPageSize] === memBaseParams[fieldPageSize]) {
+            delete filters[fieldPageSize];
+          }
+        } else {
+          if (filters[fieldPageSize] === defaultPageSize) {
+            delete filters[fieldPageSize];
+          }
+        }
+        if (memForceParams) {
+          Object.keys(memForceParams).forEach((key) => {
+            delete filters[key];
+          });
+        }
+        if (memBaseParams) {
+          Object.keys(memBaseParams).forEach((key) => {
+            if (deepEqual(filters[key], memBaseParams[key])) {
+              delete filters[key];
+            }
+          });
+        }
+        onFiltersChange(filters);
+      }
+    }, [fieldPage, fieldPageSize, defaultPageSize, memBaseParams, memForceParams, innerFilters, onFiltersChange]);
+
+    const currentPageRef = useRef(DEFAULT_PAGE);
+
+    const doFetch = useCallback(
+      (page, append = false) => {
+        if (!isActive || !restful) {
+          return;
+        }
+        if (append) {
+          setLoadingMore(true);
+        } else {
+          setLoading(true);
+        }
+        const params = { ...innerFilters, [fieldPage]: page };
+        delete params[REFRESH_COUNTER_KEY];
+        const _config = {
+          params,
+          ...reqConfigRef.current,
+        };
+        if (memParseOptions) {
+          _config.paramsSerializer = (p) => globalConfig.queryStringify(p, memParseOptions);
+        }
+        makeRequest({ delay: append ? 0 : 200, key: append ? "restlist-more" : "restlist" })
+          .get(restful, _config)
+          .then((response) => {
+            const data = findDataByPath(response.data, parseRowsPath);
+            const _total = findDataByPath(response.data, parseTotalPath);
+            currentPageRef.current = page;
+            if (append) {
+              setInnerData((prev) => ({
+                dataSource: [...prev.dataSource, ...(data || [])],
+                total: _total || prev.total,
+              }));
+            } else {
+              setInnerData({ dataSource: data || [], total: _total || 0 });
+            }
+          })
+          .finally(() => {
+            if (append) {
+              setLoadingMore(false);
+            } else {
+              setLoading(false);
+            }
+          });
+      },
+      [isActive, makeRequest, restful, parseRowsPath, parseTotalPath, innerFilters, memParseOptions, fieldPage]
+    );
+
+    const fetchData = useCallback(() => {
+      if (usePagination) {
+        doFetch(innerFilters[fieldPage] || DEFAULT_PAGE);
+      } else {
+        currentPageRef.current = DEFAULT_PAGE;
+        doFetch(DEFAULT_PAGE);
+      }
+    }, [usePagination, doFetch, innerFilters, fieldPage]);
+
+    useEffect(() => {
+      if (!innerFilters[fieldPage]) {
+        return;
+      }
+      fetchData();
+    }, [innerFilters, fetchData, fieldPage]);
+
+    const fetchMore = useCallback(() => {
+      doFetch(currentPageRef.current + 1, true);
+    }, [doFetch]);
+
+    const hasMore = useMemo(() => {
+      return innerData.dataSource.length < innerData.total;
+    }, [innerData.dataSource.length, innerData.total]);
+
+    useImperativeHandle(
+      ref,
+      () => ({
+        refreshList: fetchData,
+        fetchMore,
+        getDataSource: () => innerData,
+      }),
+      [fetchData, fetchMore, innerData]
+    );
+
+    // pagination 优先级高于 loadMore：当 pagination 启用时，loadMore 不渲染
+    const loadMoreView = useMemo(() => {
+      if (usePagination || !restful || !hasMore) {
+        return null;
+      }
+      return (
+        <div style={{ textAlign: "center", marginTop: 12, marginBottom: 12 }}>
+          <Button onClick={fetchMore} loading={loadingMore}>
+            加载更多
+          </Button>
+        </div>
+      );
+    }, [usePagination, restful, hasMore, fetchMore, loadingMore]);
+
+    const paginationConfig = useMemo(() => {
+      if (!usePagination) {
+        return false;
+      }
+      const paginationProps = pagination === true ? {} : pagination;
+      return {
+        size: "small",
+        showSizeChanger: true,
+        showQuickJumper: true,
+        showTotal: (total) => <span>总计：{total} 条</span>,
+        ...paginationProps,
+        current: innerFilters[fieldPage],
+        pageSize: innerFilters[fieldPageSize],
+        total: restful ? innerData.total : undefined,
+        onChange: (page, newPageSize) => {
+          setFilterState({
+            paginationFilters: {
+              ...filterState.paginationFilters,
+              [fieldPage]: page,
+              [fieldPageSize]: newPageSize,
+            },
+          });
+          if (isFunction(paginationProps?.onChange)) {
+            paginationProps.onChange(page, newPageSize);
+          }
+        },
+      };
+    }, [
+      usePagination,
+      pagination,
+      innerFilters,
+      innerData.total,
+      restful,
+      fieldPage,
+      fieldPageSize,
+      filterState.paginationFilters,
+      setFilterState,
+    ]);
+
+    const hasHeader = useMemo(() => {
+      return restful && !isEmpty(filterFormProps);
+    }, [filterFormProps, restful]);
+
+    const headerView = useMemo(() => {
+      if (!hasHeader) {
+        return undefined;
+      }
+      return (
+        <Spin spinning={loading}>
+          <GridForm
+            key="filterForm"
+            submitTitle="搜索"
+            {...filterFormProps}
+            fields={filterFields}
+            initialValues={{ ...memBaseParams, ...filterFormProps?.initialValues }}
+            ref={filterFormRef}
+            onSubmit={(values) => {
+              const newV = { ...values };
+              formFiltersRef.current = newV;
+              setFilterState({
+                paginationFilters: {
+                  ...filterState.paginationFilters,
+                  [fieldPage]: 1,
+                  [REFRESH_COUNTER_KEY]: (filterState.paginationFilters[REFRESH_COUNTER_KEY] || 0) + 1,
+                },
+                formFilters: newV,
+              });
+            }}
+            onReset={(values) => {
+              const newV = { ...values };
+              filterFormProps?.fields?.forEach((field) => {
+                const key = genColumnKey(field);
+                if (!filterFieldKeys.includes(key)) {
+                  newV[key] = null;
+                }
+              });
+              formFiltersRef.current = newV;
+              setFilterState({
+                paginationFilters: {
+                  ...filterState.paginationFilters,
+                  [fieldPage]: 1,
+                  [REFRESH_COUNTER_KEY]: (filterState.paginationFilters[REFRESH_COUNTER_KEY] || 0) + 1,
+                },
+                formFilters: newV,
+              });
+            }}
+          />
+        </Spin>
+      );
+    }, [
+      hasHeader,
+      loading,
+      filterFormProps,
+      filterFields,
+      memBaseParams,
+      filterFieldKeys,
+      filterState.paginationFilters,
+      fieldPage,
+      setFilterState,
+    ]);
+
+    return (
+      <List
+        style={style}
+        className={className}
+        grid={grid}
+        {...antdListProps}
+        loading={loading && !loadingMore}
+        header={headerView}
+        loadMore={loadMoreView}
+        pagination={paginationConfig}
+        rowKey={rowKey}
+        dataSource={innerData.dataSource}
+        renderItem={renderItem}
+      />
+    );
+  }
+);
+
+RestList.propTypes = {
+  style: PropTypes.object,
+  className: PropTypes.string,
+
+  restful: PropTypes.string,
+  reqConfig: PropTypes.object,
+  parseOptions: PropTypes.object,
+  baseParams: PropTypes.object,
+  routeParams: PropTypes.object,
+  forceParams: PropTypes.object,
+  fieldPage: PropTypes.string,
+  fieldPageSize: PropTypes.string,
+  defaultPageSize: PropTypes.number,
+  parseRowsPath: PropTypes.string,
+  parseTotalPath: PropTypes.string,
+  isActive: PropTypes.bool,
+  onFiltersChange: PropTypes.func,
+  onDataSourceChange: PropTypes.func,
+
+  rowKey: PropTypes.string,
+  dataSource: PropTypes.array,
+  renderItem: PropTypes.func,
+  grid: PropTypes.shape({
+    gutter: PropTypes.number,
+    column: PropTypes.number,
+    xs: PropTypes.number,
+    sm: PropTypes.number,
+    md: PropTypes.number,
+    lg: PropTypes.number,
+    xl: PropTypes.number,
+    xxl: PropTypes.number,
+  }),
+  pagination: PropTypes.oneOfType([PropTypes.bool, PropTypes.object]),
+  filterFormProps: PropTypes.object,
+  antdListProps: PropTypes.object,
+};
+RestList.displayName = "RestList";
+RestList.Item = List.Item;
+
+export default RestList;

--- a/src/components/RestList.jsx
+++ b/src/components/RestList.jsx
@@ -1,6 +1,6 @@
 import React, { forwardRef, useCallback, useEffect, useImperativeHandle, useMemo, useRef, useState } from "react";
 import PropTypes from "prop-types";
-import { Button, List, Spin } from "antd";
+import { Button, List, Space, Spin } from "antd";
 import { dequal as deepEqual } from "dequal";
 import { DEFAULT_PAGE, DEFAULT_PAGE_SIZE, DEFAULT_ROWS_PATH, FieldType } from "src/common/constants";
 import { clearEmptyValue, findDataByPath, genColumnKey, genFields, handleFormValues } from "src/common/parser";
@@ -39,7 +39,9 @@ const RestList = forwardRef(
       grid,
       pagination,
       antdListProps,
+      antdSpaceProps,
       filterFormProps,
+      loadMoreProps,
     },
     ref
   ) => {
@@ -280,14 +282,17 @@ const RestList = forwardRef(
       if (usePagination || !restful || !hasMore) {
         return null;
       }
+      if (isFunction(loadMoreProps?.render)) {
+        return loadMoreProps.render(fetchMore, loadingMore, hasMore);
+      }
       return (
-        <div style={{ textAlign: "center", marginTop: 12, marginBottom: 12 }}>
+        <div style={{ textAlign: "center", marginTop: 12, marginBottom: 12, ...loadMoreProps?.style }}>
           <Button onClick={fetchMore} loading={loadingMore}>
-            加载更多
+            {loadMoreProps?.text || "加载更多"}
           </Button>
         </div>
       );
-    }, [usePagination, restful, hasMore, fetchMore, loadingMore]);
+    }, [usePagination, restful, hasMore, fetchMore, loadingMore, loadMoreProps]);
 
     const paginationConfig = useMemo(() => {
       if (!usePagination) {
@@ -337,50 +342,47 @@ const RestList = forwardRef(
         return undefined;
       }
       return (
-        <Spin spinning={loading}>
-          <GridForm
-            key="filterForm"
-            submitTitle="搜索"
-            {...filterFormProps}
-            fields={filterFields}
-            initialValues={{ ...memBaseParams, ...filterFormProps?.initialValues }}
-            ref={filterFormRef}
-            onSubmit={(values) => {
-              const newV = { ...values };
-              formFiltersRef.current = newV;
-              setFilterState({
-                paginationFilters: {
-                  ...filterState.paginationFilters,
-                  [fieldPage]: 1,
-                  [REFRESH_COUNTER_KEY]: (filterState.paginationFilters[REFRESH_COUNTER_KEY] || 0) + 1,
-                },
-                formFilters: newV,
-              });
-            }}
-            onReset={(values) => {
-              const newV = { ...values };
-              filterFormProps?.fields?.forEach((field) => {
-                const key = genColumnKey(field);
-                if (!filterFieldKeys.includes(key)) {
-                  newV[key] = null;
-                }
-              });
-              formFiltersRef.current = newV;
-              setFilterState({
-                paginationFilters: {
-                  ...filterState.paginationFilters,
-                  [fieldPage]: 1,
-                  [REFRESH_COUNTER_KEY]: (filterState.paginationFilters[REFRESH_COUNTER_KEY] || 0) + 1,
-                },
-                formFilters: newV,
-              });
-            }}
-          />
-        </Spin>
+        <GridForm
+          key="filterForm"
+          submitTitle="搜索"
+          {...filterFormProps}
+          fields={filterFields}
+          initialValues={{ ...memBaseParams, ...filterFormProps?.initialValues }}
+          ref={filterFormRef}
+          onSubmit={(values) => {
+            const newV = { ...values };
+            formFiltersRef.current = newV;
+            setFilterState({
+              paginationFilters: {
+                ...filterState.paginationFilters,
+                [fieldPage]: 1,
+                [REFRESH_COUNTER_KEY]: (filterState.paginationFilters[REFRESH_COUNTER_KEY] || 0) + 1,
+              },
+              formFilters: newV,
+            });
+          }}
+          onReset={(values) => {
+            const newV = { ...values };
+            filterFormProps?.fields?.forEach((field) => {
+              const key = genColumnKey(field);
+              if (!filterFieldKeys.includes(key)) {
+                newV[key] = null;
+              }
+            });
+            formFiltersRef.current = newV;
+            setFilterState({
+              paginationFilters: {
+                ...filterState.paginationFilters,
+                [fieldPage]: 1,
+                [REFRESH_COUNTER_KEY]: (filterState.paginationFilters[REFRESH_COUNTER_KEY] || 0) + 1,
+              },
+              formFilters: newV,
+            });
+          }}
+        />
       );
     }, [
       hasHeader,
-      loading,
       filterFormProps,
       filterFields,
       memBaseParams,
@@ -391,19 +393,22 @@ const RestList = forwardRef(
     ]);
 
     return (
-      <List
-        style={style}
-        className={className}
-        grid={grid}
-        {...antdListProps}
-        loading={loading && !loadingMore}
-        header={headerView}
-        loadMore={loadMoreView}
-        pagination={paginationConfig}
-        rowKey={rowKey}
-        dataSource={innerData.dataSource}
-        renderItem={renderItem}
-      />
+      <Spin spinning={loading && !loadingMore}>
+        <Space direction="vertical" {...antdSpaceProps} style={{ width: "100%", ...antdSpaceProps?.style }}>
+          {headerView}
+          <List
+            style={style}
+            className={className}
+            grid={grid}
+            {...antdListProps}
+            loadMore={loadMoreView}
+            pagination={paginationConfig}
+            rowKey={rowKey}
+            dataSource={innerData.dataSource}
+            renderItem={renderItem}
+          />
+        </Space>
+      </Spin>
     );
   }
 );
@@ -443,6 +448,12 @@ RestList.propTypes = {
   pagination: PropTypes.oneOfType([PropTypes.bool, PropTypes.object]),
   filterFormProps: PropTypes.object,
   antdListProps: PropTypes.object,
+  antdSpaceProps: PropTypes.object,
+  loadMoreProps: PropTypes.shape({
+    style: PropTypes.object,
+    text: PropTypes.string,
+    render: PropTypes.func,
+  }),
 };
 RestList.displayName = "RestList";
 RestList.Item = List.Item;

--- a/src/components/RouteBaseTable.jsx
+++ b/src/components/RouteBaseTable.jsx
@@ -1,14 +1,22 @@
 import React, { forwardRef, useCallback, useEffect, useRef, useState } from "react";
 import PropTypes from "prop-types";
 import { dequal as deepEqual } from "dequal";
+import { ViewType } from "src/common/constants";
 import { guessQueryTypes, parseQueryTypes } from "src/common/parser";
 import { isEmpty, isFunction } from "src/common/typeTools";
+import RestList from "src/components/RestList";
 import RestTable from "src/components/RestTable";
 import globalConfig from "src/config";
 import { useDeepCompareMemoize } from "src/hooks";
 
 // 因为兼容不了react-router v5和v6 版本，所以传递 location 进来，然后父类组件实现路由的变更
-const RouteBaseTable = forwardRef(({ location, onSearchChange, restProps }, ref) => {
+// viewType="list" 一般与 pagination 配合使用；loadMore 模式数据追加累积，不适合通过 URL 参数还原状态
+const VIEW_TYPE_MAP = {
+  [ViewType.LIST]: RestList,
+  [ViewType.TABLE]: RestTable,
+};
+
+const RouteBaseTable = forwardRef(({ location, onSearchChange, viewType = ViewType.TABLE, restProps }, ref) => {
   const {
     parseOptions,
     parseTypes,
@@ -16,6 +24,7 @@ const RouteBaseTable = forwardRef(({ location, onSearchChange, restProps }, ref)
     columns,
     filterFormProps,
   } = restProps;
+  const ViewComponent = VIEW_TYPE_MAP[viewType] || RestTable;
   const searchRef = useRef(location.search);
 
   const memParseOptions = useDeepCompareMemoize(parseOptions);
@@ -88,16 +97,16 @@ const RouteBaseTable = forwardRef(({ location, onSearchChange, restProps }, ref)
   );
 
   if (params === undefined || params === null || guessTypes === null) {
-    // 等待params根据search初始化完成
     return null;
   }
 
-  return <RestTable ref={ref} {...restProps} routeParams={params} onFiltersChange={onChange} />;
+  return <ViewComponent ref={ref} {...restProps} routeParams={params} onFiltersChange={onChange} />;
 });
 
 RouteBaseTable.propTypes = {
   location: PropTypes.object,
   onSearchChange: PropTypes.func,
+  viewType: PropTypes.oneOf(ViewType.map((o) => o.value)),
   restProps: PropTypes.object,
 };
 

--- a/src/entry.js
+++ b/src/entry.js
@@ -1,6 +1,7 @@
 export { default as formitems } from "./components/formitems/index";
 
 export { default as RestTable } from "./components/RestTable";
+export { default as RestList } from "./components/RestList";
 export { default as LongText } from "./components/LongText";
 export { default as CopyView } from "./components/CopyView";
 export { default as GridForm } from "./components/GridForm";

--- a/tests/RestList.test.jsx
+++ b/tests/RestList.test.jsx
@@ -1,0 +1,742 @@
+import React from "react";
+import { act, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { DEFAULT_PAGE_SIZE } from "src/common/constants";
+import RestList from "src/components/RestList";
+
+const mockMakeRequest = jest.fn();
+jest.mock("src/requests", () => ({
+  useSafeRequest: () => [mockMakeRequest],
+}));
+
+jest.mock("src/hooks", () => ({
+  ...jest.requireActual("src/hooks"),
+}));
+
+describe("RestList", () => {
+  let user;
+
+  beforeEach(() => {
+    user = userEvent.setup();
+    mockMakeRequest.mockClear();
+    jest.spyOn(console, "error").mockImplementation(() => {});
+    jest.spyOn(console, "warn").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  describe("基本渲染测试", () => {
+    it("should render basic list with static dataSource", () => {
+      const dataSource = [
+        { id: 1, name: "张三" },
+        { id: 2, name: "李四" },
+      ];
+
+      render(
+        <RestList
+          dataSource={dataSource}
+          renderItem={(item) => (
+            <RestList.Item key={item.id}>
+              <span>{item.name}</span>
+            </RestList.Item>
+          )}
+        />
+      );
+
+      expect(screen.getByText("张三")).toBeInTheDocument();
+      expect(screen.getByText("李四")).toBeInTheDocument();
+    });
+
+    it("should render with custom style and className", () => {
+      const { container } = render(
+        <RestList
+          style={{ backgroundColor: "red" }}
+          className="custom-list"
+          dataSource={[{ id: 1, name: "张三" }]}
+          renderItem={(item) => <RestList.Item key={item.id}>{item.name}</RestList.Item>}
+        />
+      );
+
+      const list = container.querySelector(".ant-list");
+      expect(list).toHaveStyle("background-color: red");
+      expect(list).toHaveClass("custom-list");
+    });
+
+    it("should expose RestList.Item as List.Item", () => {
+      expect(RestList.Item).toBeDefined();
+      expect(RestList.displayName).toBe("RestList");
+    });
+  });
+
+  describe("远程数据请求测试", () => {
+    it("should make API request when restful is provided", async () => {
+      const mockResponse = {
+        data: {
+          results: [
+            { id: 1, name: "张三" },
+            { id: 2, name: "李四" },
+          ],
+          count: 2,
+        },
+      };
+
+      mockMakeRequest.mockReturnValue({
+        get: jest.fn().mockResolvedValue(mockResponse),
+      });
+
+      render(
+        <RestList
+          restful="/api/users"
+          renderItem={(item) => <RestList.Item key={item.id}>{item.name}</RestList.Item>}
+        />
+      );
+
+      await waitFor(() => {
+        expect(mockMakeRequest).toHaveBeenCalledWith({ delay: 200, key: "restlist" });
+      });
+
+      const mockGet = mockMakeRequest().get;
+      expect(mockGet).toHaveBeenCalledWith("/api/users", {
+        params: {
+          page: 1,
+          page_size: DEFAULT_PAGE_SIZE, // eslint-disable-line camelcase
+        },
+      });
+    });
+
+    it("should not make request when isActive is false", () => {
+      render(
+        <RestList
+          restful="/api/users"
+          isActive={false}
+          renderItem={(item) => <RestList.Item key={item.id}>{item.name}</RestList.Item>}
+        />
+      );
+
+      expect(mockMakeRequest).not.toHaveBeenCalled();
+    });
+
+    it("should handle API response correctly", async () => {
+      const mockResponse = {
+        data: {
+          results: [
+            { id: 1, name: "张三" },
+            { id: 2, name: "李四" },
+          ],
+          count: 2,
+        },
+      };
+
+      mockMakeRequest.mockReturnValue({
+        get: jest.fn().mockResolvedValue(mockResponse),
+      });
+
+      render(
+        <RestList
+          restful="/api/users"
+          renderItem={(item) => <RestList.Item key={item.id}>{item.name}</RestList.Item>}
+        />
+      );
+
+      await waitFor(() => {
+        expect(screen.getByText("张三")).toBeInTheDocument();
+        expect(screen.getByText("李四")).toBeInTheDocument();
+      });
+    });
+
+    it("should handle custom parseRowsPath and parseTotalPath", async () => {
+      const mockResponse = {
+        data: {
+          data: {
+            items: [{ id: 1, name: "张三" }],
+            total: 1,
+          },
+        },
+      };
+
+      mockMakeRequest.mockReturnValue({
+        get: jest.fn().mockResolvedValue(mockResponse),
+      });
+
+      render(
+        <RestList
+          restful="/api/users"
+          parseRowsPath="data.items"
+          parseTotalPath="data.total"
+          renderItem={(item) => <RestList.Item key={item.id}>{item.name}</RestList.Item>}
+        />
+      );
+
+      await waitFor(() => {
+        expect(screen.getByText("张三")).toBeInTheDocument();
+      });
+    });
+
+    it("should use custom fieldPage and fieldPageSize", async () => {
+      const mockResponse = {
+        data: { results: [{ id: 1, name: "张三" }], count: 1 },
+      };
+
+      mockMakeRequest.mockReturnValue({
+        get: jest.fn().mockResolvedValue(mockResponse),
+      });
+
+      render(
+        <RestList
+          restful="/api/users"
+          fieldPage="current"
+          fieldPageSize="size"
+          renderItem={(item) => <RestList.Item key={item.id}>{item.name}</RestList.Item>}
+        />
+      );
+
+      await waitFor(() => {
+        const mockGet = mockMakeRequest().get;
+        expect(mockGet).toHaveBeenCalledWith("/api/users", {
+          params: {
+            current: 1,
+            size: DEFAULT_PAGE_SIZE,
+          },
+        });
+      });
+    });
+  });
+
+  describe("loadMore 模式测试", () => {
+    it("should show load more button when there is more data", async () => {
+      const mockResponse = {
+        data: {
+          results: [{ id: 1, name: "张三" }],
+          count: 5,
+        },
+      };
+
+      mockMakeRequest.mockReturnValue({
+        get: jest.fn().mockResolvedValue(mockResponse),
+      });
+
+      render(
+        <RestList
+          restful="/api/users"
+          defaultPageSize={2}
+          renderItem={(item) => <RestList.Item key={item.id}>{item.name}</RestList.Item>}
+        />
+      );
+
+      await waitFor(() => {
+        expect(screen.getByText("加载更多")).toBeInTheDocument();
+      });
+    });
+
+    it("should not show load more button when all data is loaded", async () => {
+      const mockResponse = {
+        data: {
+          results: [{ id: 1, name: "张三" }],
+          count: 1,
+        },
+      };
+
+      mockMakeRequest.mockReturnValue({
+        get: jest.fn().mockResolvedValue(mockResponse),
+      });
+
+      render(
+        <RestList
+          restful="/api/users"
+          renderItem={(item) => <RestList.Item key={item.id}>{item.name}</RestList.Item>}
+        />
+      );
+
+      await waitFor(() => {
+        expect(screen.getByText("张三")).toBeInTheDocument();
+      });
+
+      expect(screen.queryByText("加载更多")).not.toBeInTheDocument();
+    });
+
+    it("should append data when load more is clicked", async () => {
+      const mockGet = jest.fn();
+      mockGet
+        .mockResolvedValueOnce({
+          data: { results: [{ id: 1, name: "张三" }], count: 2 },
+        })
+        .mockResolvedValueOnce({
+          data: { results: [{ id: 2, name: "李四" }], count: 2 },
+        });
+
+      mockMakeRequest.mockReturnValue({ get: mockGet });
+
+      render(
+        <RestList
+          restful="/api/users"
+          defaultPageSize={1}
+          renderItem={(item) => <RestList.Item key={item.id}>{item.name}</RestList.Item>}
+        />
+      );
+
+      await waitFor(() => {
+        expect(screen.getByText("张三")).toBeInTheDocument();
+      });
+
+      const loadMoreBtn = screen.getByText("加载更多");
+      await act(async () => {
+        await user.click(loadMoreBtn);
+      });
+
+      await waitFor(() => {
+        expect(screen.getByText("张三")).toBeInTheDocument();
+        expect(screen.getByText("李四")).toBeInTheDocument();
+      });
+    });
+  });
+
+  describe("pagination 模式测试", () => {
+    it("should not show load more button when pagination is enabled", async () => {
+      const mockResponse = {
+        data: {
+          results: [{ id: 1, name: "张三" }],
+          count: 5,
+        },
+      };
+
+      mockMakeRequest.mockReturnValue({
+        get: jest.fn().mockResolvedValue(mockResponse),
+      });
+
+      render(
+        <RestList
+          restful="/api/users"
+          defaultPageSize={2}
+          pagination={true}
+          renderItem={(item) => <RestList.Item key={item.id}>{item.name}</RestList.Item>}
+        />
+      );
+
+      await waitFor(() => {
+        expect(screen.getByText("张三")).toBeInTheDocument();
+      });
+
+      expect(screen.queryByText("加载更多")).not.toBeInTheDocument();
+    });
+
+    it("should show total count in pagination", async () => {
+      const mockResponse = {
+        data: {
+          results: [{ id: 1, name: "张三" }],
+          count: 100,
+        },
+      };
+
+      mockMakeRequest.mockReturnValue({
+        get: jest.fn().mockResolvedValue(mockResponse),
+      });
+
+      render(
+        <RestList
+          restful="/api/users"
+          pagination={true}
+          renderItem={(item) => <RestList.Item key={item.id}>{item.name}</RestList.Item>}
+        />
+      );
+
+      await waitFor(() => {
+        expect(screen.getByText("总计：100 条")).toBeInTheDocument();
+      });
+    });
+
+    it("should accept pagination as object with custom config", async () => {
+      const mockResponse = {
+        data: {
+          results: [{ id: 1, name: "张三" }],
+          count: 10,
+        },
+      };
+
+      mockMakeRequest.mockReturnValue({
+        get: jest.fn().mockResolvedValue(mockResponse),
+      });
+
+      render(
+        <RestList
+          restful="/api/users"
+          defaultPageSize={2}
+          pagination={{ showSizeChanger: true, pageSizeOptions: [2, 4, 10] }}
+          renderItem={(item) => <RestList.Item key={item.id}>{item.name}</RestList.Item>}
+        />
+      );
+
+      await waitFor(() => {
+        expect(screen.getByText("张三")).toBeInTheDocument();
+      });
+    });
+  });
+
+  describe("grid + page_size 校验测试", () => {
+    it("should log console.error when page_size is not multiple of grid.column", async () => {
+      const consoleSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+
+      mockMakeRequest.mockReturnValue({
+        get: jest.fn().mockResolvedValue({
+          data: { results: [{ id: 1, name: "张三" }], count: 1 },
+        }),
+      });
+
+      render(
+        <RestList
+          restful="/api/users/"
+          defaultPageSize={3}
+          grid={{ gutter: 16, column: 2 }}
+          renderItem={(item) => <RestList.Item key={item.id}>{item.name}</RestList.Item>}
+        />
+      );
+
+      await waitFor(() => {
+        expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining("page_size=3 必须是 grid.column=2 的倍数"));
+      });
+    });
+
+    it("should include restful in the error message", async () => {
+      const consoleSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+
+      mockMakeRequest.mockReturnValue({
+        get: jest.fn().mockResolvedValue({
+          data: { results: [], count: 0 },
+        }),
+      });
+
+      render(
+        <RestList
+          restful="/api/items/"
+          defaultPageSize={5}
+          grid={{ gutter: 16, column: 3 }}
+          renderItem={(item) => <RestList.Item key={item.id}>{item.name}</RestList.Item>}
+        />
+      );
+
+      await waitFor(() => {
+        expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('restful="/api/items/"'));
+      });
+    });
+
+    it("should not log error when page_size is valid multiple", async () => {
+      const consoleSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+
+      mockMakeRequest.mockReturnValue({
+        get: jest.fn().mockResolvedValue({
+          data: { results: [{ id: 1, name: "张三" }], count: 1 },
+        }),
+      });
+
+      render(
+        <RestList
+          restful="/api/users/"
+          defaultPageSize={4}
+          grid={{ gutter: 16, column: 2 }}
+          renderItem={(item) => <RestList.Item key={item.id}>{item.name}</RestList.Item>}
+        />
+      );
+
+      await waitFor(() => {
+        expect(screen.getByText("张三")).toBeInTheDocument();
+      });
+
+      const gridErrors = consoleSpy.mock.calls.filter(
+        (call) => typeof call[0] === "string" && call[0].includes("grid.column")
+      );
+      expect(gridErrors).toHaveLength(0);
+    });
+  });
+
+  describe("filterFormProps 测试", () => {
+    it("should render filter form in header when filterFormProps is provided", () => {
+      mockMakeRequest.mockReturnValue({
+        get: jest.fn().mockResolvedValue({
+          data: { results: [], count: 0 },
+        }),
+      });
+
+      const { container } = render(
+        <RestList
+          restful="/api/users"
+          filterFormProps={{
+            fields: [{ key: "name", label: "姓名", type: "input" }],
+          }}
+          renderItem={(item) => <RestList.Item key={item.id}>{item.name}</RestList.Item>}
+        />
+      );
+
+      expect(container.querySelector(".ant-form")).toBeInTheDocument();
+    });
+
+    it("should not render filter form when restful is not provided", () => {
+      const { container } = render(
+        <RestList
+          dataSource={[{ id: 1, name: "张三" }]}
+          filterFormProps={{
+            fields: [{ key: "name", label: "姓名", type: "input" }],
+          }}
+          renderItem={(item) => <RestList.Item key={item.id}>{item.name}</RestList.Item>}
+        />
+      );
+
+      expect(container.querySelector(".ant-form")).not.toBeInTheDocument();
+    });
+
+    it("should trigger search when form is submitted", async () => {
+      const mockGet = jest.fn().mockResolvedValue({
+        data: { results: [{ id: 1, name: "张三" }], count: 1 },
+      });
+      mockMakeRequest.mockReturnValue({ get: mockGet });
+
+      const { container } = render(
+        <RestList
+          restful="/api/users"
+          filterFormProps={{
+            fields: [{ key: "name", label: "姓名", type: "input" }],
+          }}
+          renderItem={(item) => <RestList.Item key={item.id}>{item.name}</RestList.Item>}
+        />
+      );
+
+      const submitButton = container.querySelector('button[type="submit"]');
+      await act(async () => {
+        await user.click(submitButton);
+      });
+
+      await waitFor(() => {
+        expect(mockGet).toHaveBeenCalledWith("/api/users", {
+          params: expect.objectContaining({ page: 1 }),
+        });
+      });
+    });
+  });
+
+  describe("回调函数测试", () => {
+    it("should call onDataSourceChange when data changes", async () => {
+      const mockResponse = {
+        data: {
+          results: [{ id: 1, name: "张三" }],
+          count: 1,
+        },
+      };
+
+      mockMakeRequest.mockReturnValue({
+        get: jest.fn().mockResolvedValue(mockResponse),
+      });
+
+      const onDataSourceChange = jest.fn();
+
+      render(
+        <RestList
+          restful="/api/users"
+          onDataSourceChange={onDataSourceChange}
+          renderItem={(item) => <RestList.Item key={item.id}>{item.name}</RestList.Item>}
+        />
+      );
+
+      await waitFor(() => {
+        expect(onDataSourceChange).toHaveBeenCalledWith({
+          dataSource: [{ id: 1, name: "张三" }],
+          total: 1,
+        });
+      });
+    });
+
+    it("should call onFiltersChange when filters change", async () => {
+      mockMakeRequest.mockReturnValue({
+        get: jest.fn().mockResolvedValue({
+          data: { results: [], count: 0 },
+        }),
+      });
+
+      const onFiltersChange = jest.fn();
+
+      render(
+        <RestList
+          restful="/api/users"
+          onFiltersChange={onFiltersChange}
+          renderItem={(item) => <RestList.Item key={item.id}>{item.name}</RestList.Item>}
+        />
+      );
+
+      await waitFor(() => {
+        expect(onFiltersChange).toHaveBeenCalledWith({});
+      });
+    });
+  });
+
+  describe("参数合并测试", () => {
+    it("should merge baseParams, routeParams, and forceParams", async () => {
+      const mockResponse = {
+        data: { results: [{ id: 1, name: "张三" }], count: 1 },
+      };
+
+      mockMakeRequest.mockReturnValue({
+        get: jest.fn().mockResolvedValue(mockResponse),
+      });
+
+      render(
+        <RestList
+          restful="/api/users"
+          baseParams={{ status: "active" }}
+          routeParams={{ search: "test" }}
+          forceParams={{ category: "tech" }}
+          renderItem={(item) => <RestList.Item key={item.id}>{item.name}</RestList.Item>}
+        />
+      );
+
+      await waitFor(() => {
+        const mockGet = mockMakeRequest().get;
+        expect(mockGet).toHaveBeenCalledWith("/api/users", {
+          params: expect.objectContaining({
+            status: "active",
+            search: "test",
+            category: "tech",
+          }),
+        });
+      });
+    });
+
+    it("should prioritize forceParams over other params", async () => {
+      mockMakeRequest.mockReturnValue({
+        get: jest.fn().mockResolvedValue({
+          data: { results: [], count: 0 },
+        }),
+      });
+
+      render(
+        <RestList
+          restful="/api/users"
+          baseParams={{ status: "active" }}
+          routeParams={{ status: "inactive" }}
+          forceParams={{ status: "pending" }}
+          renderItem={(item) => <RestList.Item key={item.id}>{item.name}</RestList.Item>}
+        />
+      );
+
+      await waitFor(() => {
+        const mockGet = mockMakeRequest().get;
+        expect(mockGet).toHaveBeenCalledWith("/api/users", {
+          params: expect.objectContaining({
+            status: "pending",
+          }),
+        });
+      });
+    });
+  });
+
+  describe("ref 方法测试", () => {
+    it("should expose refreshList, fetchMore, and getDataSource methods", async () => {
+      mockMakeRequest.mockReturnValue({
+        get: jest.fn().mockResolvedValue({
+          data: { results: [{ id: 1, name: "张三" }], count: 1 },
+        }),
+      });
+
+      const listRef = React.createRef();
+
+      render(
+        <RestList
+          ref={listRef}
+          restful="/api/users"
+          renderItem={(item) => <RestList.Item key={item.id}>{item.name}</RestList.Item>}
+        />
+      );
+
+      await waitFor(() => {
+        expect(listRef.current).toBeDefined();
+        expect(typeof listRef.current.refreshList).toBe("function");
+        expect(typeof listRef.current.fetchMore).toBe("function");
+        expect(typeof listRef.current.getDataSource).toBe("function");
+      });
+    });
+
+    it("should return current data from getDataSource", async () => {
+      mockMakeRequest.mockReturnValue({
+        get: jest.fn().mockResolvedValue({
+          data: { results: [{ id: 1, name: "张三" }], count: 1 },
+        }),
+      });
+
+      const listRef = React.createRef();
+
+      render(
+        <RestList
+          ref={listRef}
+          restful="/api/users"
+          renderItem={(item) => <RestList.Item key={item.id}>{item.name}</RestList.Item>}
+        />
+      );
+
+      await waitFor(() => {
+        const data = listRef.current.getDataSource();
+        expect(data.dataSource).toEqual([{ id: 1, name: "张三" }]);
+        expect(data.total).toBe(1);
+      });
+    });
+  });
+
+  describe("快照测试", () => {
+    it("should match snapshot with basic props", () => {
+      const { container } = render(
+        <RestList
+          dataSource={[
+            { id: 1, name: "张三" },
+            { id: 2, name: "李四" },
+          ]}
+          renderItem={(item) => <RestList.Item key={item.id}>{item.name}</RestList.Item>}
+        />
+      );
+      expect(container.firstChild).toMatchSnapshot();
+    });
+
+    it("should match snapshot with grid", () => {
+      const { container } = render(
+        <RestList
+          dataSource={[{ id: 1, name: "张三" }]}
+          grid={{ gutter: 16, column: 2 }}
+          renderItem={(item) => <RestList.Item key={item.id}>{item.name}</RestList.Item>}
+        />
+      );
+      expect(container.firstChild).toMatchSnapshot();
+    });
+
+    it("should match snapshot with pagination", () => {
+      mockMakeRequest.mockReturnValue({
+        get: jest.fn().mockResolvedValue({
+          data: { results: [], count: 0 },
+        }),
+      });
+
+      const { container } = render(
+        <RestList
+          restful="/api/users"
+          pagination={true}
+          renderItem={(item) => <RestList.Item key={item.id}>{item.name}</RestList.Item>}
+        />
+      );
+      expect(container.firstChild).toMatchSnapshot();
+    });
+
+    it("should match snapshot with filter form", () => {
+      mockMakeRequest.mockReturnValue({
+        get: jest.fn().mockResolvedValue({
+          data: { results: [], count: 0 },
+        }),
+      });
+
+      const { container } = render(
+        <RestList
+          restful="/api/users"
+          filterFormProps={{
+            fields: [{ key: "name", label: "姓名", type: "input" }],
+          }}
+          renderItem={(item) => <RestList.Item key={item.id}>{item.name}</RestList.Item>}
+        />
+      );
+      expect(container.firstChild).toMatchSnapshot();
+    });
+  });
+});

--- a/tests/RestList.test.jsx
+++ b/tests/RestList.test.jsx
@@ -292,6 +292,86 @@ describe("RestList", () => {
     });
   });
 
+  describe("loadMoreProps 自定义测试", () => {
+    it("should render custom text from loadMoreProps.text", async () => {
+      mockMakeRequest.mockReturnValue({
+        get: jest.fn().mockResolvedValue({
+          data: { results: [{ id: 1, name: "张三" }], count: 5 },
+        }),
+      });
+
+      render(
+        <RestList
+          restful="/api/users"
+          defaultPageSize={2}
+          loadMoreProps={{ text: "展开更多" }}
+          renderItem={(item) => <RestList.Item key={item.id}>{item.name}</RestList.Item>}
+        />
+      );
+
+      await waitFor(() => {
+        expect(screen.getByText("展开更多")).toBeInTheDocument();
+      });
+      expect(screen.queryByText("加载更多")).not.toBeInTheDocument();
+    });
+
+    it("should apply custom style from loadMoreProps.style", async () => {
+      mockMakeRequest.mockReturnValue({
+        get: jest.fn().mockResolvedValue({
+          data: { results: [{ id: 1, name: "张三" }], count: 5 },
+        }),
+      });
+
+      render(
+        <RestList
+          restful="/api/users"
+          defaultPageSize={2}
+          loadMoreProps={{ style: { marginTop: 30 } }}
+          renderItem={(item) => <RestList.Item key={item.id}>{item.name}</RestList.Item>}
+        />
+      );
+
+      await waitFor(() => {
+        const btn = screen.getByRole("button", { name: "加载更多" });
+        const container = btn.parentElement;
+        expect(container).toHaveStyle("margin-top: 30px");
+        expect(container).toHaveStyle("text-align: center");
+      });
+    });
+
+    it("should use custom render function from loadMoreProps.render", async () => {
+      mockMakeRequest.mockReturnValue({
+        get: jest.fn().mockResolvedValue({
+          data: { results: [{ id: 1, name: "张三" }], count: 5 },
+        }),
+      });
+
+      const customRender = jest.fn((fetchMore, loadingMore) => (
+        <button onClick={fetchMore} disabled={loadingMore}>
+          自定义加载
+        </button>
+      ));
+
+      render(
+        <RestList
+          restful="/api/users"
+          defaultPageSize={2}
+          loadMoreProps={{ render: customRender }}
+          renderItem={(item) => <RestList.Item key={item.id}>{item.name}</RestList.Item>}
+        />
+      );
+
+      await waitFor(() => {
+        expect(screen.getByText("自定义加载")).toBeInTheDocument();
+      });
+      expect(customRender).toHaveBeenCalledWith(
+        expect.any(Function),
+        expect.any(Boolean),
+        expect.any(Boolean)
+      );
+    });
+  });
+
   describe("pagination 模式测试", () => {
     it("should not show load more button when pagination is enabled", async () => {
       const mockResponse = {
@@ -450,7 +530,7 @@ describe("RestList", () => {
   });
 
   describe("filterFormProps 测试", () => {
-    it("should render filter form in header when filterFormProps is provided", () => {
+    it("should render filter form when filterFormProps is provided", () => {
       mockMakeRequest.mockReturnValue({
         get: jest.fn().mockResolvedValue({
           data: { results: [], count: 0 },

--- a/tests/__snapshots__/RestList.test.jsx.snap
+++ b/tests/__snapshots__/RestList.test.jsx.snap
@@ -1,0 +1,407 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`RestList 快照测试 should match snapshot with basic props 1`] = `
+<div
+  class="ant-list ant-list-split css-dev-only-do-not-override-1kf000u"
+>
+  <div
+    class="ant-spin-nested-loading css-dev-only-do-not-override-1kf000u"
+  >
+    <div
+      class="ant-spin-container"
+    >
+      <ul
+        class="ant-list-items"
+      >
+        <li
+          class="ant-list-item"
+        >
+          张三
+        </li>
+        <li
+          class="ant-list-item"
+        >
+          李四
+        </li>
+      </ul>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`RestList 快照测试 should match snapshot with filter form 1`] = `
+<div
+  class="ant-list ant-list-split ant-list-loading css-dev-only-do-not-override-1kf000u"
+>
+  <div
+    class="ant-list-header"
+  >
+    <div
+      class="ant-spin-nested-loading css-dev-only-do-not-override-1kf000u"
+    >
+      <div
+        class="ant-spin-container"
+      >
+        <form
+          class="ant-form ant-form-horizontal css-dev-only-do-not-override-1kf000u"
+        >
+          <div
+            class="ant-list ant-list-split ant-list-grid css-dev-only-do-not-override-1kf000u"
+          >
+            <div
+              class="ant-spin-nested-loading css-dev-only-do-not-override-1kf000u"
+            >
+              <div
+                class="ant-spin-container"
+              >
+                <div
+                  class="ant-row css-dev-only-do-not-override-1kf000u"
+                  style="margin-left: -5px; margin-right: -5px;"
+                >
+                  <div
+                    style="width: 33.333333333333336%; max-width: 33.333333333333336%;"
+                  >
+                    <div
+                      class="ant-col css-dev-only-do-not-override-1kf000u"
+                      style="padding-left: 5px; padding-right: 5px; flex: 1 1 auto;"
+                    >
+                      <div
+                        class="ant-list-item"
+                      >
+                        <div
+                          class="ant-form-item css-dev-only-do-not-override-1kf000u ant-form-item-has-success"
+                          style="margin-bottom: 0px;"
+                        >
+                          <div
+                            class="ant-row ant-form-item-row css-dev-only-do-not-override-1kf000u"
+                          >
+                            <div
+                              class="ant-col ant-form-item-label css-dev-only-do-not-override-1kf000u"
+                              style="flex: 0 0 80px;"
+                            >
+                              <label
+                                class=""
+                                for="name"
+                                title="姓名"
+                              >
+                                姓名
+                              </label>
+                            </div>
+                            <div
+                              class="ant-col ant-form-item-control css-dev-only-do-not-override-1kf000u"
+                            >
+                              <div
+                                class="ant-form-item-control-input"
+                              >
+                                <div
+                                  class="ant-form-item-control-input-content"
+                                >
+                                  <input
+                                    class="ant-input css-dev-only-do-not-override-1kf000u ant-input-outlined ant-input-status-success"
+                                    id="name"
+                                    type="text"
+                                    value=""
+                                  />
+                                </div>
+                              </div>
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                  <div
+                    style="width: 33.333333333333336%; max-width: 33.333333333333336%;"
+                  >
+                    <div
+                      class="ant-col css-dev-only-do-not-override-1kf000u"
+                      style="padding-left: 5px; padding-right: 5px; flex: 1 1 auto;"
+                    >
+                      <div
+                        class="ant-list-item"
+                      >
+                        <div
+                          class="ant-form-item css-dev-only-do-not-override-1kf000u"
+                          style="margin-bottom: 0px;"
+                        >
+                          <div
+                            class="ant-row ant-form-item-row css-dev-only-do-not-override-1kf000u"
+                          >
+                            <div
+                              class="ant-col ant-form-item-control css-dev-only-do-not-override-1kf000u"
+                            >
+                              <div
+                                class="ant-form-item-control-input"
+                              >
+                                <div
+                                  class="ant-form-item-control-input-content"
+                                >
+                                  <div
+                                    class="ant-space css-dev-only-do-not-override-1kf000u ant-space-horizontal ant-space-align-center ant-space-gap-row-small ant-space-gap-col-small"
+                                    style="margin-left: 80px;"
+                                  >
+                                    <div
+                                      class="ant-space-item"
+                                    >
+                                      <button
+                                        class="ant-btn css-dev-only-do-not-override-1kf000u ant-btn-primary ant-btn-color-primary ant-btn-variant-solid"
+                                        type="submit"
+                                      >
+                                        <span>
+                                          搜 索
+                                        </span>
+                                      </button>
+                                    </div>
+                                    <div
+                                      class="ant-space-item"
+                                    >
+                                      <button
+                                        class="ant-btn css-dev-only-do-not-override-1kf000u ant-btn-default ant-btn-color-default ant-btn-variant-outlined"
+                                        type="reset"
+                                      >
+                                        <span>
+                                          重 置
+                                        </span>
+                                      </button>
+                                    </div>
+                                  </div>
+                                </div>
+                              </div>
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </form>
+      </div>
+    </div>
+  </div>
+  <div
+    class="ant-spin-nested-loading css-dev-only-do-not-override-1kf000u"
+  >
+    <div
+      class="ant-spin-container"
+    >
+      <div
+        style="min-height: 53px;"
+      />
+    </div>
+  </div>
+</div>
+`;
+
+exports[`RestList 快照测试 should match snapshot with grid 1`] = `
+<div
+  class="ant-list ant-list-split ant-list-grid css-dev-only-do-not-override-1kf000u"
+>
+  <div
+    class="ant-spin-nested-loading css-dev-only-do-not-override-1kf000u"
+  >
+    <div
+      class="ant-spin-container"
+    >
+      <div
+        class="ant-row css-dev-only-do-not-override-1kf000u"
+        style="margin-left: -8px; margin-right: -8px;"
+      >
+        <div
+          style="width: 50%; max-width: 50%;"
+        >
+          <div
+            class="ant-col css-dev-only-do-not-override-1kf000u"
+            style="padding-left: 8px; padding-right: 8px; flex: 1 1 auto;"
+          >
+            <div
+              class="ant-list-item"
+            >
+              张三
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`RestList 快照测试 should match snapshot with pagination 1`] = `
+<div
+  class="ant-list ant-list-split ant-list-loading ant-list-something-after-last-item css-dev-only-do-not-override-1kf000u"
+>
+  <div
+    class="ant-spin-nested-loading css-dev-only-do-not-override-1kf000u"
+  >
+    <div
+      class="ant-spin-container"
+    >
+      <div
+        style="min-height: 53px;"
+      />
+    </div>
+  </div>
+  <div
+    class="ant-list-pagination"
+  >
+    <ul
+      class="ant-pagination ant-pagination-end ant-pagination-mini css-dev-only-do-not-override-1kf000u"
+    >
+      <li
+        class="ant-pagination-total-text"
+      >
+        <span>
+          总计：
+          0
+           条
+        </span>
+      </li>
+      <li
+        aria-disabled="true"
+        class="ant-pagination-prev ant-pagination-disabled"
+        title="Previous Page"
+      >
+        <button
+          class="ant-pagination-item-link"
+          disabled=""
+          tabindex="-1"
+          type="button"
+        >
+          <span
+            aria-label="left"
+            class="anticon anticon-left"
+            role="img"
+          >
+            <svg
+              aria-hidden="true"
+              data-icon="left"
+              fill="currentColor"
+              focusable="false"
+              height="1em"
+              viewBox="64 64 896 896"
+              width="1em"
+            >
+              <path
+                d="M724 218.3V141c0-6.7-7.7-10.4-12.9-6.3L260.3 486.8a31.86 31.86 0 000 50.3l450.8 352.1c5.3 4.1 12.9.4 12.9-6.3v-77.3c0-4.9-2.3-9.6-6.1-12.6l-360-281 360-281.1c3.8-3 6.1-7.7 6.1-12.6z"
+              />
+            </svg>
+          </span>
+        </button>
+      </li>
+      <li
+        class="ant-pagination-item ant-pagination-item-1 ant-pagination-item-disabled"
+        tabindex="0"
+        title="1"
+      >
+        <a
+          rel="nofollow"
+        >
+          1
+        </a>
+      </li>
+      <li
+        aria-disabled="true"
+        class="ant-pagination-next ant-pagination-disabled"
+        title="Next Page"
+      >
+        <button
+          class="ant-pagination-item-link"
+          disabled=""
+          tabindex="-1"
+          type="button"
+        >
+          <span
+            aria-label="right"
+            class="anticon anticon-right"
+            role="img"
+          >
+            <svg
+              aria-hidden="true"
+              data-icon="right"
+              fill="currentColor"
+              focusable="false"
+              height="1em"
+              viewBox="64 64 896 896"
+              width="1em"
+            >
+              <path
+                d="M765.7 486.8L314.9 134.7A7.97 7.97 0 00302 141v77.3c0 4.9 2.3 9.6 6.1 12.6l360 281.1-360 281.1c-3.9 3-6.1 7.7-6.1 12.6V883c0 6.7 7.7 10.4 12.9 6.3l450.8-352.1a31.96 31.96 0 000-50.4z"
+              />
+            </svg>
+          </span>
+        </button>
+      </li>
+      <li
+        class="ant-pagination-options"
+      >
+        <div
+          aria-label="Page Size"
+          class="ant-select ant-select-sm ant-select-outlined ant-pagination-options-size-changer css-dev-only-do-not-override-1kf000u ant-select-single ant-select-show-arrow ant-select-show-search"
+        >
+          <div
+            class="ant-select-selector"
+          >
+            <span
+              class="ant-select-selection-wrap"
+            >
+              <span
+                class="ant-select-selection-search"
+              >
+                <input
+                  aria-autocomplete="list"
+                  aria-controls="rc_select_TEST_OR_SSR_list"
+                  aria-expanded="false"
+                  aria-haspopup="listbox"
+                  aria-label="Page Size"
+                  aria-owns="rc_select_TEST_OR_SSR_list"
+                  autocomplete="off"
+                  class="ant-select-selection-search-input"
+                  id="rc_select_TEST_OR_SSR"
+                  role="combobox"
+                  type="search"
+                  value=""
+                />
+              </span>
+              <span
+                class="ant-select-selection-item"
+                title="20 / page"
+              >
+                20 / page
+              </span>
+            </span>
+          </div>
+          <span
+            aria-hidden="true"
+            class="ant-select-arrow"
+            style="user-select: none;"
+            unselectable="on"
+          >
+            <span
+              aria-label="down"
+              class="anticon anticon-down ant-select-suffix"
+              role="img"
+            >
+              <svg
+                aria-hidden="true"
+                data-icon="down"
+                fill="currentColor"
+                focusable="false"
+                height="1em"
+                viewBox="64 64 896 896"
+                width="1em"
+              >
+                <path
+                  d="M884 256h-75c-5.1 0-9.9 2.5-12.9 6.6L512 654.2 227.9 262.6c-3-4.1-7.8-6.6-12.9-6.6h-75c-6.5 0-10.3 7.4-6.5 12.7l352.6 486.1c12.8 17.6 39 17.6 51.7 0l352.6-486.1c3.9-5.3.1-12.7-6.4-12.7z"
+                />
+              </svg>
+            </span>
+          </span>
+        </div>
+      </li>
+    </ul>
+  </div>
+</div>
+`;

--- a/tests/__snapshots__/RestList.test.jsx.snap
+++ b/tests/__snapshots__/RestList.test.jsx.snap
@@ -2,28 +2,45 @@
 
 exports[`RestList 快照测试 should match snapshot with basic props 1`] = `
 <div
-  class="ant-list ant-list-split css-dev-only-do-not-override-1kf000u"
+  class="ant-spin-nested-loading css-dev-only-do-not-override-1kf000u"
 >
   <div
-    class="ant-spin-nested-loading css-dev-only-do-not-override-1kf000u"
+    class="ant-spin-container"
   >
     <div
-      class="ant-spin-container"
+      class="ant-space css-dev-only-do-not-override-1kf000u ant-space-vertical ant-space-gap-row-small ant-space-gap-col-small"
+      style="width: 100%;"
     >
-      <ul
-        class="ant-list-items"
+      <div
+        class="ant-space-item"
       >
-        <li
-          class="ant-list-item"
+        <div
+          class="ant-list ant-list-split css-dev-only-do-not-override-1kf000u"
         >
-          张三
-        </li>
-        <li
-          class="ant-list-item"
-        >
-          李四
-        </li>
-      </ul>
+          <div
+            class="ant-spin-nested-loading css-dev-only-do-not-override-1kf000u"
+          >
+            <div
+              class="ant-spin-container"
+            >
+              <ul
+                class="ant-list-items"
+              >
+                <li
+                  class="ant-list-item"
+                >
+                  张三
+                </li>
+                <li
+                  class="ant-list-item"
+                >
+                  李四
+                </li>
+              </ul>
+            </div>
+          </div>
+        </div>
+      </div>
     </div>
   </div>
 </div>
@@ -31,16 +48,17 @@ exports[`RestList 快照测试 should match snapshot with basic props 1`] = `
 
 exports[`RestList 快照测试 should match snapshot with filter form 1`] = `
 <div
-  class="ant-list ant-list-split ant-list-loading css-dev-only-do-not-override-1kf000u"
+  class="ant-spin-nested-loading css-dev-only-do-not-override-1kf000u"
 >
   <div
-    class="ant-list-header"
+    class="ant-spin-container"
   >
     <div
-      class="ant-spin-nested-loading css-dev-only-do-not-override-1kf000u"
+      class="ant-space css-dev-only-do-not-override-1kf000u ant-space-vertical ant-space-gap-row-small ant-space-gap-col-small"
+      style="width: 100%;"
     >
       <div
-        class="ant-spin-container"
+        class="ant-space-item"
       >
         <form
           class="ant-form ant-form-horizontal css-dev-only-do-not-override-1kf000u"
@@ -179,17 +197,74 @@ exports[`RestList 快照测试 should match snapshot with filter form 1`] = `
           </div>
         </form>
       </div>
-    </div>
-  </div>
-  <div
-    class="ant-spin-nested-loading css-dev-only-do-not-override-1kf000u"
-  >
-    <div
-      class="ant-spin-container"
-    >
       <div
-        style="min-height: 53px;"
-      />
+        class="ant-space-item"
+      >
+        <div
+          class="ant-list ant-list-split css-dev-only-do-not-override-1kf000u"
+        >
+          <div
+            class="ant-spin-nested-loading css-dev-only-do-not-override-1kf000u"
+          >
+            <div
+              class="ant-spin-container"
+            >
+              <div
+                class="ant-list-empty-text"
+              >
+                <div
+                  class="css-dev-only-do-not-override-1kf000u ant-empty ant-empty-normal"
+                >
+                  <div
+                    class="ant-empty-image"
+                  >
+                    <svg
+                      height="41"
+                      viewBox="0 0 64 41"
+                      width="64"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <title>
+                        No data
+                      </title>
+                      <g
+                        fill="none"
+                        fill-rule="evenodd"
+                        transform="translate(0 1)"
+                      >
+                        <ellipse
+                          cx="32"
+                          cy="33"
+                          fill="#f5f5f5"
+                          rx="32"
+                          ry="7"
+                        />
+                        <g
+                          fill-rule="nonzero"
+                          stroke="#d9d9d9"
+                        >
+                          <path
+                            d="M55 12.76L44.854 1.258C44.367.474 43.656 0 42.907 0H21.093c-.749 0-1.46.474-1.947 1.257L9 12.761V22h46v-9.24z"
+                          />
+                          <path
+                            d="M41.613 15.931c0-1.605.994-2.93 2.227-2.931H55v18.137C55 33.26 53.68 35 52.05 35h-40.1C10.32 35 9 33.259 9 31.137V13h11.16c1.233 0 2.227 1.323 2.227 2.928v.022c0 1.605 1.005 2.901 2.237 2.901h14.752c1.232 0 2.237-1.308 2.237-2.913v-.007z"
+                            fill="#fafafa"
+                          />
+                        </g>
+                      </g>
+                    </svg>
+                  </div>
+                  <div
+                    class="ant-empty-description"
+                  >
+                    No data
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
     </div>
   </div>
 </div>
@@ -197,29 +272,46 @@ exports[`RestList 快照测试 should match snapshot with filter form 1`] = `
 
 exports[`RestList 快照测试 should match snapshot with grid 1`] = `
 <div
-  class="ant-list ant-list-split ant-list-grid css-dev-only-do-not-override-1kf000u"
+  class="ant-spin-nested-loading css-dev-only-do-not-override-1kf000u"
 >
   <div
-    class="ant-spin-nested-loading css-dev-only-do-not-override-1kf000u"
+    class="ant-spin-container"
   >
     <div
-      class="ant-spin-container"
+      class="ant-space css-dev-only-do-not-override-1kf000u ant-space-vertical ant-space-gap-row-small ant-space-gap-col-small"
+      style="width: 100%;"
     >
       <div
-        class="ant-row css-dev-only-do-not-override-1kf000u"
-        style="margin-left: -8px; margin-right: -8px;"
+        class="ant-space-item"
       >
         <div
-          style="width: 50%; max-width: 50%;"
+          class="ant-list ant-list-split ant-list-grid css-dev-only-do-not-override-1kf000u"
         >
           <div
-            class="ant-col css-dev-only-do-not-override-1kf000u"
-            style="padding-left: 8px; padding-right: 8px; flex: 1 1 auto;"
+            class="ant-spin-nested-loading css-dev-only-do-not-override-1kf000u"
           >
             <div
-              class="ant-list-item"
+              class="ant-spin-container"
             >
-              张三
+              <div
+                class="ant-row css-dev-only-do-not-override-1kf000u"
+                style="margin-left: -8px; margin-right: -8px;"
+              >
+                <div
+                  style="width: 50%; max-width: 50%;"
+                >
+                  <div
+                    class="ant-col css-dev-only-do-not-override-1kf000u"
+                    style="padding-left: 8px; padding-right: 8px; flex: 1 1 auto;"
+                  >
+                    <div
+                      class="ant-list-item"
+                    >
+                      张三
+                    </div>
+                  </div>
+                </div>
+              </div>
             </div>
           </div>
         </div>
@@ -231,177 +323,243 @@ exports[`RestList 快照测试 should match snapshot with grid 1`] = `
 
 exports[`RestList 快照测试 should match snapshot with pagination 1`] = `
 <div
-  class="ant-list ant-list-split ant-list-loading ant-list-something-after-last-item css-dev-only-do-not-override-1kf000u"
+  class="ant-spin-nested-loading css-dev-only-do-not-override-1kf000u"
 >
   <div
-    class="ant-spin-nested-loading css-dev-only-do-not-override-1kf000u"
+    class="ant-spin-container"
   >
     <div
-      class="ant-spin-container"
+      class="ant-space css-dev-only-do-not-override-1kf000u ant-space-vertical ant-space-gap-row-small ant-space-gap-col-small"
+      style="width: 100%;"
     >
       <div
-        style="min-height: 53px;"
-      />
-    </div>
-  </div>
-  <div
-    class="ant-list-pagination"
-  >
-    <ul
-      class="ant-pagination ant-pagination-end ant-pagination-mini css-dev-only-do-not-override-1kf000u"
-    >
-      <li
-        class="ant-pagination-total-text"
-      >
-        <span>
-          总计：
-          0
-           条
-        </span>
-      </li>
-      <li
-        aria-disabled="true"
-        class="ant-pagination-prev ant-pagination-disabled"
-        title="Previous Page"
-      >
-        <button
-          class="ant-pagination-item-link"
-          disabled=""
-          tabindex="-1"
-          type="button"
-        >
-          <span
-            aria-label="left"
-            class="anticon anticon-left"
-            role="img"
-          >
-            <svg
-              aria-hidden="true"
-              data-icon="left"
-              fill="currentColor"
-              focusable="false"
-              height="1em"
-              viewBox="64 64 896 896"
-              width="1em"
-            >
-              <path
-                d="M724 218.3V141c0-6.7-7.7-10.4-12.9-6.3L260.3 486.8a31.86 31.86 0 000 50.3l450.8 352.1c5.3 4.1 12.9.4 12.9-6.3v-77.3c0-4.9-2.3-9.6-6.1-12.6l-360-281 360-281.1c3.8-3 6.1-7.7 6.1-12.6z"
-              />
-            </svg>
-          </span>
-        </button>
-      </li>
-      <li
-        class="ant-pagination-item ant-pagination-item-1 ant-pagination-item-disabled"
-        tabindex="0"
-        title="1"
-      >
-        <a
-          rel="nofollow"
-        >
-          1
-        </a>
-      </li>
-      <li
-        aria-disabled="true"
-        class="ant-pagination-next ant-pagination-disabled"
-        title="Next Page"
-      >
-        <button
-          class="ant-pagination-item-link"
-          disabled=""
-          tabindex="-1"
-          type="button"
-        >
-          <span
-            aria-label="right"
-            class="anticon anticon-right"
-            role="img"
-          >
-            <svg
-              aria-hidden="true"
-              data-icon="right"
-              fill="currentColor"
-              focusable="false"
-              height="1em"
-              viewBox="64 64 896 896"
-              width="1em"
-            >
-              <path
-                d="M765.7 486.8L314.9 134.7A7.97 7.97 0 00302 141v77.3c0 4.9 2.3 9.6 6.1 12.6l360 281.1-360 281.1c-3.9 3-6.1 7.7-6.1 12.6V883c0 6.7 7.7 10.4 12.9 6.3l450.8-352.1a31.96 31.96 0 000-50.4z"
-              />
-            </svg>
-          </span>
-        </button>
-      </li>
-      <li
-        class="ant-pagination-options"
+        class="ant-space-item"
       >
         <div
-          aria-label="Page Size"
-          class="ant-select ant-select-sm ant-select-outlined ant-pagination-options-size-changer css-dev-only-do-not-override-1kf000u ant-select-single ant-select-show-arrow ant-select-show-search"
+          class="ant-list ant-list-split ant-list-something-after-last-item css-dev-only-do-not-override-1kf000u"
         >
           <div
-            class="ant-select-selector"
+            class="ant-spin-nested-loading css-dev-only-do-not-override-1kf000u"
           >
-            <span
-              class="ant-select-selection-wrap"
+            <div
+              class="ant-spin-container"
             >
-              <span
-                class="ant-select-selection-search"
+              <div
+                class="ant-list-empty-text"
               >
-                <input
-                  aria-autocomplete="list"
-                  aria-controls="rc_select_TEST_OR_SSR_list"
-                  aria-expanded="false"
-                  aria-haspopup="listbox"
-                  aria-label="Page Size"
-                  aria-owns="rc_select_TEST_OR_SSR_list"
-                  autocomplete="off"
-                  class="ant-select-selection-search-input"
-                  id="rc_select_TEST_OR_SSR"
-                  role="combobox"
-                  type="search"
-                  value=""
-                />
-              </span>
-              <span
-                class="ant-select-selection-item"
-                title="20 / page"
-              >
-                20 / page
-              </span>
-            </span>
+                <div
+                  class="css-dev-only-do-not-override-1kf000u ant-empty ant-empty-normal"
+                >
+                  <div
+                    class="ant-empty-image"
+                  >
+                    <svg
+                      height="41"
+                      viewBox="0 0 64 41"
+                      width="64"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <title>
+                        No data
+                      </title>
+                      <g
+                        fill="none"
+                        fill-rule="evenodd"
+                        transform="translate(0 1)"
+                      >
+                        <ellipse
+                          cx="32"
+                          cy="33"
+                          fill="#f5f5f5"
+                          rx="32"
+                          ry="7"
+                        />
+                        <g
+                          fill-rule="nonzero"
+                          stroke="#d9d9d9"
+                        >
+                          <path
+                            d="M55 12.76L44.854 1.258C44.367.474 43.656 0 42.907 0H21.093c-.749 0-1.46.474-1.947 1.257L9 12.761V22h46v-9.24z"
+                          />
+                          <path
+                            d="M41.613 15.931c0-1.605.994-2.93 2.227-2.931H55v18.137C55 33.26 53.68 35 52.05 35h-40.1C10.32 35 9 33.259 9 31.137V13h11.16c1.233 0 2.227 1.323 2.227 2.928v.022c0 1.605 1.005 2.901 2.237 2.901h14.752c1.232 0 2.237-1.308 2.237-2.913v-.007z"
+                            fill="#fafafa"
+                          />
+                        </g>
+                      </g>
+                    </svg>
+                  </div>
+                  <div
+                    class="ant-empty-description"
+                  >
+                    No data
+                  </div>
+                </div>
+              </div>
+            </div>
           </div>
-          <span
-            aria-hidden="true"
-            class="ant-select-arrow"
-            style="user-select: none;"
-            unselectable="on"
+          <div
+            class="ant-list-pagination"
           >
-            <span
-              aria-label="down"
-              class="anticon anticon-down ant-select-suffix"
-              role="img"
+            <ul
+              class="ant-pagination ant-pagination-end ant-pagination-mini css-dev-only-do-not-override-1kf000u"
             >
-              <svg
-                aria-hidden="true"
-                data-icon="down"
-                fill="currentColor"
-                focusable="false"
-                height="1em"
-                viewBox="64 64 896 896"
-                width="1em"
+              <li
+                class="ant-pagination-total-text"
               >
-                <path
-                  d="M884 256h-75c-5.1 0-9.9 2.5-12.9 6.6L512 654.2 227.9 262.6c-3-4.1-7.8-6.6-12.9-6.6h-75c-6.5 0-10.3 7.4-6.5 12.7l352.6 486.1c12.8 17.6 39 17.6 51.7 0l352.6-486.1c3.9-5.3.1-12.7-6.4-12.7z"
-                />
-              </svg>
-            </span>
-          </span>
+                <span>
+                  总计：
+                  0
+                   条
+                </span>
+              </li>
+              <li
+                aria-disabled="true"
+                class="ant-pagination-prev ant-pagination-disabled"
+                title="Previous Page"
+              >
+                <button
+                  class="ant-pagination-item-link"
+                  disabled=""
+                  tabindex="-1"
+                  type="button"
+                >
+                  <span
+                    aria-label="left"
+                    class="anticon anticon-left"
+                    role="img"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      data-icon="left"
+                      fill="currentColor"
+                      focusable="false"
+                      height="1em"
+                      viewBox="64 64 896 896"
+                      width="1em"
+                    >
+                      <path
+                        d="M724 218.3V141c0-6.7-7.7-10.4-12.9-6.3L260.3 486.8a31.86 31.86 0 000 50.3l450.8 352.1c5.3 4.1 12.9.4 12.9-6.3v-77.3c0-4.9-2.3-9.6-6.1-12.6l-360-281 360-281.1c3.8-3 6.1-7.7 6.1-12.6z"
+                      />
+                    </svg>
+                  </span>
+                </button>
+              </li>
+              <li
+                class="ant-pagination-item ant-pagination-item-1 ant-pagination-item-disabled"
+                tabindex="0"
+                title="1"
+              >
+                <a
+                  rel="nofollow"
+                >
+                  1
+                </a>
+              </li>
+              <li
+                aria-disabled="true"
+                class="ant-pagination-next ant-pagination-disabled"
+                title="Next Page"
+              >
+                <button
+                  class="ant-pagination-item-link"
+                  disabled=""
+                  tabindex="-1"
+                  type="button"
+                >
+                  <span
+                    aria-label="right"
+                    class="anticon anticon-right"
+                    role="img"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      data-icon="right"
+                      fill="currentColor"
+                      focusable="false"
+                      height="1em"
+                      viewBox="64 64 896 896"
+                      width="1em"
+                    >
+                      <path
+                        d="M765.7 486.8L314.9 134.7A7.97 7.97 0 00302 141v77.3c0 4.9 2.3 9.6 6.1 12.6l360 281.1-360 281.1c-3.9 3-6.1 7.7-6.1 12.6V883c0 6.7 7.7 10.4 12.9 6.3l450.8-352.1a31.96 31.96 0 000-50.4z"
+                      />
+                    </svg>
+                  </span>
+                </button>
+              </li>
+              <li
+                class="ant-pagination-options"
+              >
+                <div
+                  aria-label="Page Size"
+                  class="ant-select ant-select-sm ant-select-outlined ant-pagination-options-size-changer css-dev-only-do-not-override-1kf000u ant-select-single ant-select-show-arrow ant-select-show-search"
+                >
+                  <div
+                    class="ant-select-selector"
+                  >
+                    <span
+                      class="ant-select-selection-wrap"
+                    >
+                      <span
+                        class="ant-select-selection-search"
+                      >
+                        <input
+                          aria-autocomplete="list"
+                          aria-controls="rc_select_TEST_OR_SSR_list"
+                          aria-expanded="false"
+                          aria-haspopup="listbox"
+                          aria-label="Page Size"
+                          aria-owns="rc_select_TEST_OR_SSR_list"
+                          autocomplete="off"
+                          class="ant-select-selection-search-input"
+                          id="rc_select_TEST_OR_SSR"
+                          role="combobox"
+                          type="search"
+                          value=""
+                        />
+                      </span>
+                      <span
+                        class="ant-select-selection-item"
+                        title="20 / page"
+                      >
+                        20 / page
+                      </span>
+                    </span>
+                  </div>
+                  <span
+                    aria-hidden="true"
+                    class="ant-select-arrow"
+                    style="user-select: none;"
+                    unselectable="on"
+                  >
+                    <span
+                      aria-label="down"
+                      class="anticon anticon-down ant-select-suffix"
+                      role="img"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        data-icon="down"
+                        fill="currentColor"
+                        focusable="false"
+                        height="1em"
+                        viewBox="64 64 896 896"
+                        width="1em"
+                      >
+                        <path
+                          d="M884 256h-75c-5.1 0-9.9 2.5-12.9 6.6L512 654.2 227.9 262.6c-3-4.1-7.8-6.6-12.9-6.6h-75c-6.5 0-10.3 7.4-6.5 12.7l352.6 486.1c12.8 17.6 39 17.6 51.7 0l352.6-486.1c3.9-5.3.1-12.7-6.4-12.7z"
+                        />
+                      </svg>
+                    </span>
+                  </span>
+                </div>
+              </li>
+            </ul>
+          </div>
         </div>
-      </li>
-    </ul>
+      </div>
+    </div>
   </div>
 </div>
 `;


### PR DESCRIPTION
- feat: 新增 `RestList` 组件，基于 Ant Design List 封装，支持远程数据加载
    - 支持 loadMore（加载更多）和 pagination（分页器）两种模式，pagination 优先级高于 loadMore
    - 支持 filterFormProps 筛选表单，渲染在 List header 中
    - 支持 grid 栅格布局，并校验 page_size 与 grid.column 的倍数关系（不满足时 console.error）
    - renderItem 直接暴露，不封装 List.Item；提供 `RestList.Item` 等同于 `List.Item`
- feat: 新增 `ViewType` 枚举（`constants.ViewType`），包含 TABLE 和 LIST 两个值
- feat: `RouteBaseTable` 新增 `viewType` 参数，支持通过 `ViewType.LIST` 切换为 RestList 渲染
    - viewType="list" 推荐与 pagination 配合使用，不推荐与 loadMore 结合
- docs: 优化组件使用说明文档