### PR TITLE
feat: 扩展UploadView新增参数preserveResponse

### DIFF
--- a/docs/CHANGELOG-0.x.md
+++ b/docs/CHANGELOG-0.x.md
@@ -1,5 +1,9 @@
 # Release Notes
 
+## 0.3.1
+- feat: 调整 `UploadView` 新增 `preserveResponse` 参数，支持在文件对象中保留服务端返回的完整 `response` 数据
+- fix: 调整 `UploadView` 上传失败时增加 `console.error` 错误日志输出，便于排查问题
+
 ## 0.3.0
 - feat: 新增 `RestList` 组件，基于 Ant Design List 封装，支持远程数据加载
     - 支持 loadMore（加载更多）和 pagination（分页器）两种模式，pagination 优先级高于 loadMore

--- a/docs/CHANGELOG-0.x.md
+++ b/docs/CHANGELOG-0.x.md
@@ -3,6 +3,7 @@
 ## 0.3.1
 - feat: 调整 `UploadView` 新增 `preserveResponse` 参数，支持在文件对象中保留服务端返回的完整 `response` 数据
 - fix: 调整 `UploadView` 上传失败时增加 `console.error` 错误日志输出，便于排查问题
+- fix: 调整 `RestList` 延迟 `grid.column` 整除校验，等待 filters 初始化完成后再检测，避免使用默认 pageSize 提前误报
 
 ## 0.3.0
 - feat: 新增 `RestList` 组件，基于 Ant Design List 封装，支持远程数据加载

--- a/docs/reference/formitems/UploadView.md
+++ b/docs/reference/formitems/UploadView.md
@@ -27,6 +27,7 @@
 | baseParams | 上传请求的额外参数 | `object` | - | - | - |
 | enableDragger | 是否支持拖拽文件 | `boolean` | `false` | - | - |
 | maxSize | 限制文件大小（字节） | `number` | `104857600` | - | - |
+| preserveResponse | 是否在文件对象中保留服务端返回的完整 `response` 数据 | `boolean` | `false` | - | - |
 | **原生组件支持** | | | | | |
 | listType | 文件列表类型 | `string` | `'picture'` | 透传 Upload `listType` | - |
 | maxCount | 限制文件个数；0 表示不限制 | `number` | `1` | 透传 Upload `maxCount` | - |
@@ -50,6 +51,7 @@
 | size | 文件大小（字节） | `number` | ❌ |
 | type | 文件MIME类型，如 `image/png` | `string` | ❌ |
 | status | 上传状态 | `string` | ❌ |
+| response | 服务端返回的完整响应数据（仅 `preserveResponse=true` 时存在） | `object` | ❌ |
 
 ### 文件值格式示例
 组件支持两种文件值格式：
@@ -64,6 +66,25 @@
   name: "example.png",
   url: "http://example.com/uploaded.png",
   thumbUrl: "http://example.com/thumb.png"
+}
+```
+
+#### 单文件格式（preserveResponse=true）
+```javascript
+{
+  uid: "rc-upload-1748693175705-3",
+  status: "done",
+  type: "image/png",
+  size: 227310,
+  name: "example.png",
+  url: "http://example.com/uploaded.png",
+  thumbUrl: "http://example.com/thumb.png",
+  response: {
+    url: "http://example.com/uploaded.png",
+    thumbUrl: "http://example.com/thumb.png",
+    id: 123,
+    path: "/uploads/example.png"
+  }
 }
 ```
 
@@ -138,6 +159,22 @@ const ImageUploadView = () => {
       listType="picture-card"
       maxCount={6}
       baseParams={{ type: 'image' }}
+    />
+  );
+};
+
+// 保留服务端响应数据示例
+const KeepResponseUploadView = () => {
+  const [fileList, setFileList] = useState([]);
+
+  // 启用 preserveResponse 后，onChange 回调中的文件对象会包含 response 字段
+  // response 为服务端接口返回的完整数据，例如 { url: "...", thumbUrl: "...", id: 123, path: "/uploads/..." }
+  return (
+    <UploadView
+      uploadUrl="/api/upload"
+      value={fileList}
+      onChange={setFileList}
+      preserveResponse
     />
   );
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "antd-restful",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "author": "SkylerHu",
   "private": false,
   "main": "dist/index.js",

--- a/src/components/RestList.jsx
+++ b/src/components/RestList.jsx
@@ -106,13 +106,16 @@ const RestList = forwardRef(
     }, [innerFilters, fieldPageSize, defaultPageSize]);
 
     useEffect(() => {
+      if (!innerFilters[fieldPageSize]) {
+        return;
+      }
       const column = grid?.column;
       if (column && column > 0 && pageSize % column !== 0) {
         console.error( // eslint-disable-line no-console
           `[RestList] restful="${restful}" page_size=${pageSize} 必须是 grid.column=${column} 的倍数，当前不满足，会导致列表布局不对齐。`
         );
       }
-    }, [grid?.column, pageSize, restful]);
+    }, [grid?.column, pageSize, restful, innerFilters, fieldPageSize]);
 
     useEffect(() => {
       const oldV = formFiltersRef.current;

--- a/src/components/formitems/UploadView.jsx
+++ b/src/components/formitems/UploadView.jsx
@@ -41,6 +41,7 @@ const UploadView = ({
   antdUploadProps,
   antdSpaceProps,
   antdReadonlyItemProps,
+  preserveResponse = false,
 }) => {
   const [makeRequest] = useSafeRequest();
   const reqConfigRef = useRef(reqConfig);
@@ -65,16 +66,21 @@ const UploadView = ({
         // 没有状态字段，或者状态为成功时才是表单需要的值
         // succList = succList.filter((item) => !item.status || item.status === UploadStatus.DONE);
       }
-      // 只保留必要的字段
-      succList = succList.map((item) => ({
-        uid: item.uid,
-        status: item.status,
-        type: item.type,
-        size: item.size,
-        name: item.name,
-        url: item.url || item.response?.url,
-        thumbUrl: item.thumbUrl || item.response?.thumbUrl,
-      }));
+      succList = succList.map((item) => {
+        const result = {
+          uid: item.uid,
+          status: item.status,
+          type: item.type,
+          size: item.size,
+          name: item.name,
+          url: item.url || item.response?.url,
+          thumbUrl: item.thumbUrl || item.response?.thumbUrl,
+        };
+        if (preserveResponse && item.response) {
+          result.response = item.response;
+        }
+        return result;
+      });
 
       if (isArr) {
         return succList;
@@ -85,7 +91,7 @@ const UploadView = ({
         return succList.length > 0 ? succList[0] : null;
       }
     },
-    [isMultiple]
+    [isMultiple, preserveResponse]
   );
 
   const onValueChange = useCallback(
@@ -168,7 +174,7 @@ const UploadView = ({
         .then((resp) => {
           // {"thumbUrl": "", "url": ""}
           onSuccess(resp.data);
-          updateFileInfo(fileUid, { ...resp.data, status: UploadStatus.DONE });
+          updateFileInfo(fileUid, { ...resp.data, response: resp.data, status: UploadStatus.DONE });
           message.success(`文件 ${file.name} 上传成功`);
         })
         .catch((err) => {
@@ -176,6 +182,8 @@ const UploadView = ({
           if (tmpInfo && tmpInfo.controller) {
             tmpInfo.controller.abort();
           }
+          // eslint-disable-next-line no-console
+          console.error(`[UploadView] 文件 ${file.name} 上传失败:`, err);
           onError(err);
           updateFileInfo(fileUid, { status: UploadStatus.ERROR });
           message.error(`文件 ${file.name} 上传失败`);
@@ -333,6 +341,7 @@ UploadView.propTypes = {
   antdButtonConfig: PropTypes.object,
   antdSpaceProps: PropTypes.object,
   antdReadonlyItemProps: PropTypes.object,
+  preserveResponse: PropTypes.bool,
 };
 
 export default UploadView;


### PR DESCRIPTION
- feat: 调整 `UploadView` 新增 `preserveResponse` 参数，支持在文件对象中保留服务端返回的完整 `response` 数据
- fix: 调整 `UploadView` 上传失败时增加 `console.error` 错误日志输出，便于排查问题